### PR TITLE
Revert "meson: Exploit file.full_path() for config.h"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project(
         'tests': not meson.is_subproject(),
     },
     version: '0.12.0',
-    meson_version: '>=1.4.0',
+    meson_version: '>=1.3.0',
 )
 
 if get_option('tests')
@@ -70,7 +70,7 @@ endif
 
 config = configure_file(output: 'config.h', configuration: conf)
 
-add_project_arguments('-include', config.full_path(), language: 'c')
+add_project_arguments('-include', '@0@'.format(config), language: 'c')
 
 libpldm_include_dir = include_directories('include', is_system: true)
 


### PR DESCRIPTION
This reverts commit d05ac25f8ee35d1f082ba21343ae8f053c24e46d.

This change helps maintain a stable build environment and avoids conflicts with other recipes that depend on an earlier Meson version.

Note: This is a workaround and should be reverted as part of the
      project-level Meson version bump.