### PR TITLE
platform: Add uint64/int64 commands support

### DIFF
--- a/include/libpldm/platform.h
+++ b/include/libpldm/platform.h
@@ -165,7 +165,9 @@ enum pldm_effecter_data_size {
 	PLDM_EFFECTER_DATA_SIZE_UINT16,
 	PLDM_EFFECTER_DATA_SIZE_SINT16,
 	PLDM_EFFECTER_DATA_SIZE_UINT32,
-	PLDM_EFFECTER_DATA_SIZE_SINT32
+	PLDM_EFFECTER_DATA_SIZE_SINT32,
+	PLDM_EFFECTER_DATA_SIZE_UINT64,
+	PLDM_EFFECTER_DATA_SIZE_SINT64
 };
 
 enum pldm_range_field_format {
@@ -175,9 +177,11 @@ enum pldm_range_field_format {
 	PLDM_RANGE_FIELD_FORMAT_SINT16,
 	PLDM_RANGE_FIELD_FORMAT_UINT32,
 	PLDM_RANGE_FIELD_FORMAT_SINT32,
-	PLDM_RANGE_FIELD_FORMAT_REAL32
+	PLDM_RANGE_FIELD_FORMAT_REAL32,
+	PLDM_RANGE_FIELD_FORMAT_UINT64,
+	PLDM_RANGE_FIELD_FORMAT_SINT64
 };
-#define PLDM_RANGE_FIELD_FORMAT_MAX PLDM_RANGE_FIELD_FORMAT_REAL32
+#define PLDM_RANGE_FIELD_FORMAT_MAX PLDM_RANGE_FIELD_FORMAT_SINT64
 
 enum set_request { PLDM_NO_CHANGE = 0x00, PLDM_REQUEST_SET = 0x01 };
 
@@ -386,9 +390,11 @@ enum pldm_sensor_readings_data_type {
 	PLDM_SENSOR_DATA_SIZE_UINT16,
 	PLDM_SENSOR_DATA_SIZE_SINT16,
 	PLDM_SENSOR_DATA_SIZE_UINT32,
-	PLDM_SENSOR_DATA_SIZE_SINT32
+	PLDM_SENSOR_DATA_SIZE_SINT32,
+	PLDM_SENSOR_DATA_SIZE_UINT64,
+	PLDM_SENSOR_DATA_SIZE_SINT64
 };
-#define PLDM_SENSOR_DATA_SIZE_MAX PLDM_SENSOR_DATA_SIZE_SINT32
+#define PLDM_SENSOR_DATA_SIZE_MAX PLDM_SENSOR_DATA_SIZE_SINT64
 
 /** @brief PLDM PlatformEventMessage response status
  */
@@ -735,6 +741,8 @@ typedef union {
 	int16_t value_s16;
 	uint32_t value_u32;
 	int32_t value_s32;
+	uint64_t value_u64;
+	int64_t value_s64;
 } union_effecter_data_size;
 
 /** @union union_range_field_format
@@ -751,6 +759,8 @@ typedef union {
 	uint32_t value_u32;
 	int32_t value_s32;
 	real32_t value_f32;
+	uint64_t value_u64;
+	int64_t value_s64;
 } union_range_field_format;
 
 /** @struct pldm_numeric_effecter_value_pdr
@@ -808,6 +818,8 @@ typedef union {
 	int16_t value_s16;
 	uint32_t value_u32;
 	int32_t value_s32;
+	uint64_t value_u64;
+	int64_t value_s64;
 } union_sensor_data_size;
 
 /** @struct pldm_value_pdr_hdr
@@ -1360,7 +1372,7 @@ int decode_set_numeric_effecter_value_req(const struct pldm_msg *msg,
 					  size_t payload_length,
 					  uint16_t *effecter_id,
 					  uint8_t *effecter_data_size,
-					  uint8_t effecter_value[4]);
+					  uint8_t effecter_value[8]);
 
 /** @brief Create a PLDM response message for SetNumericEffecterValue
  *

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -576,6 +576,72 @@ pldm__msgbuf_extract_real32(struct pldm_msgbuf *ctx, void *dst)
 	return pldm__msgbuf_invalidate(ctx);
 }
 
+#define pldm_msgbuf_extract_uint64(ctx, dst)                                   \
+        pldm_msgbuf_extract_typecheck(uint64_t, pldm__msgbuf_extract_uint64,   \
+                                      dst, ctx, (void *)&(dst))
+LIBPLDM_CC_NONNULL
+LIBPLDM_CC_ALWAYS_INLINE int
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+pldm__msgbuf_extract_uint64(struct pldm_msgbuf *ctx, void *dst)
+{
+	uint64_t ldst;
+
+	static_assert(
+		// NOLINTNEXTLINE(bugprone-sizeof-expression)
+		sizeof(ldst) < INTMAX_MAX,
+		"The following addition may not uphold the runtime assertion");
+
+	if (ctx->remaining >= (intmax_t)sizeof(ldst)) {
+		assert(ctx->cursor);
+		memcpy(&ldst, ctx->cursor, sizeof(ldst));
+		ldst = le64toh(ldst);
+		memcpy(dst, &ldst, sizeof(ldst));
+		ctx->cursor += sizeof(ldst);
+		ctx->remaining -= sizeof(ldst);
+		return 0;
+	}
+
+	if (ctx->remaining > INTMAX_MIN + (intmax_t)sizeof(ldst)) {
+		ctx->remaining -= sizeof(ldst);
+		return -EOVERFLOW;
+	}
+
+	return pldm__msgbuf_invalidate(ctx);
+}
+
+#define pldm_msgbuf_extract_int64(ctx, dst)                                    \
+        pldm_msgbuf_extract_typecheck(int64_t, pldm__msgbuf_extract_int64,     \
+                                      dst, ctx, (void *)&(dst))
+LIBPLDM_CC_NONNULL
+LIBPLDM_CC_ALWAYS_INLINE int
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+pldm__msgbuf_extract_int64(struct pldm_msgbuf *ctx, void *dst)
+{
+	int64_t ldst;
+
+	static_assert(
+		// NOLINTNEXTLINE(bugprone-sizeof-expression)
+		sizeof(ldst) < INTMAX_MAX,
+		"The following addition may not uphold the runtime assertion");
+
+	if (ctx->remaining >= (intmax_t)sizeof(ldst)) {
+		assert(ctx->cursor);
+		memcpy(&ldst, ctx->cursor, sizeof(ldst));
+		ldst = le64toh(ldst);
+		memcpy(dst, &ldst, sizeof(ldst));
+		ctx->cursor += sizeof(ldst);
+		ctx->remaining -= sizeof(ldst);
+		return 0;
+	}
+
+	if (ctx->remaining > INTMAX_MIN + (intmax_t)sizeof(ldst)) {
+		ctx->remaining -= sizeof(ldst);
+		return -EOVERFLOW;
+	}
+
+	return pldm__msgbuf_invalidate(ctx);
+}
+
 /**
  * Extract the field at the msgbuf cursor into the lvalue named by dst.
  *
@@ -593,7 +659,9 @@ pldm__msgbuf_extract_real32(struct pldm_msgbuf *ctx, void *dst)
 		int16_t: pldm__msgbuf_extract_int16,                           \
 		uint32_t: pldm__msgbuf_extract_uint32,                         \
 		int32_t: pldm__msgbuf_extract_int32,                           \
-		real32_t: pldm__msgbuf_extract_real32)(ctx, (void *)&(dst))
+		real32_t: pldm__msgbuf_extract_real32,                         \
+		uint64_t: pldm__msgbuf_extract_uint64,                         \
+		int64_t: pldm__msgbuf_extract_int64)(ctx, (void *)&(dst))
 
 /**
  * Extract the field at the msgbuf cursor into the object pointed-to by dst.
@@ -612,7 +680,9 @@ pldm__msgbuf_extract_real32(struct pldm_msgbuf *ctx, void *dst)
 		int16_t *: pldm__msgbuf_extract_int16,                         \
 		uint32_t *: pldm__msgbuf_extract_uint32,                       \
 		int32_t *: pldm__msgbuf_extract_int32,                         \
-		real32_t *: pldm__msgbuf_extract_real32)(ctx, dst)
+		real32_t *: pldm__msgbuf_extract_real32,                       \
+		uint64_t *: pldm__msgbuf_extract_uint64,                       \
+		int64_t *: pldm__msgbuf_extract_int64)(ctx, dst)
 
 /**
  * @ref pldm_msgbuf_extract_array
@@ -1500,6 +1570,23 @@ static inline int pldm_msgbuf_typecheck_real32_t(struct pldm_msgbuf *ctx,
 	static_assert(std::is_same<real32_t, T>::value);
 	return pldm__msgbuf_extract_real32(ctx, buf);
 }
+
+template <typename T>
+static inline int pldm_msgbuf_typecheck_uint64_t(struct pldm_msgbuf *ctx,
+						 void *buf)
+{
+	static_assert(std::is_same<uint64_t, T>::value);
+	return pldm__msgbuf_extract_uint64(ctx, buf);
+}
+
+template <typename T>
+static inline int pldm_msgbuf_typecheck_int64_t(struct pldm_msgbuf *ctx,
+						void *buf)
+{
+	static_assert(std::is_same<int64_t, T>::value);
+	return pldm__msgbuf_extract_int64(ctx, buf);
+}
+
 #endif
 
 #endif /* BUF_H */

--- a/src/msgbuf/platform.h
+++ b/src/msgbuf/platform.h
@@ -53,6 +53,10 @@ pldm_msgbuf_extract_sensor_data(struct pldm_msgbuf *ctx,
 		return pldm_msgbuf_extract(ctx, dst->value_u32);
 	case PLDM_SENSOR_DATA_SIZE_SINT32:
 		return pldm_msgbuf_extract(ctx, dst->value_s32);
+	case PLDM_SENSOR_DATA_SIZE_UINT64:
+		return pldm_msgbuf_extract(ctx, dst->value_u64);
+	case PLDM_SENSOR_DATA_SIZE_SINT64:
+		return pldm_msgbuf_extract(ctx, dst->value_s64);
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -81,6 +85,10 @@ pldm_msgbuf_extract_sensor_value(struct pldm_msgbuf *ctx,
 		return pldm__msgbuf_extract_uint32(ctx, val);
 	case PLDM_SENSOR_DATA_SIZE_SINT32:
 		return pldm__msgbuf_extract_int32(ctx, val);
+	case PLDM_SENSOR_DATA_SIZE_UINT64:
+		return pldm__msgbuf_extract_uint64(ctx, val);
+	case PLDM_SENSOR_DATA_SIZE_SINT64:
+		return pldm__msgbuf_extract_int64(ctx, val);
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -122,6 +130,14 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm__msgbuf_extract_range_field_format(
 		return pldm__msgbuf_extract_real32(
 			ctx, ((char *)rff) + offsetof(union_range_field_format,
 						      value_f32));
+	case PLDM_RANGE_FIELD_FORMAT_UINT64:
+		return pldm__msgbuf_extract_uint64(
+			ctx, ((char *)rff) + offsetof(union_range_field_format,
+						      value_u64));
+	case PLDM_RANGE_FIELD_FORMAT_SINT64:
+		return pldm__msgbuf_extract_int64(
+			ctx, ((char *)rff) + offsetof(union_range_field_format,
+						      value_s64));
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -145,6 +161,10 @@ pldm_msgbuf_extract_effecter_value(struct pldm_msgbuf *ctx,
 		return pldm__msgbuf_extract_uint32(ctx, dst);
 	case PLDM_EFFECTER_DATA_SIZE_SINT32:
 		return pldm__msgbuf_extract_int32(ctx, dst);
+	case PLDM_EFFECTER_DATA_SIZE_UINT64:
+		return pldm__msgbuf_extract_uint64(ctx, dst);
+	case PLDM_EFFECTER_DATA_SIZE_SINT64:
+		return pldm__msgbuf_extract_int64(ctx, dst);
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -183,6 +203,15 @@ pldm__msgbuf_extract_effecter_data(struct pldm_msgbuf *ctx,
 		return pldm__msgbuf_extract_int32(
 			ctx, ((char *)ed) + offsetof(union_effecter_data_size,
 						     value_s32));
+
+       case PLDM_EFFECTER_DATA_SIZE_UINT64:
+                return pldm__msgbuf_extract_uint64(
+                        ctx, ((char *)ed) + offsetof(union_effecter_data_size,
+                                                     value_u64));
+        case PLDM_EFFECTER_DATA_SIZE_SINT64:
+                return pldm__msgbuf_extract_int64(
+                        ctx, ((char *)ed) + offsetof(union_effecter_data_size,
+                                                     value_s64));
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;

--- a/tests/dsp/platform.cpp
+++ b/tests/dsp/platform.cpp
@@ -3149,7 +3149,7 @@ TEST(GetNumericEffecterValue, testBadEncodeResponse)
 
     rc = encode_get_numeric_effecter_value_resp(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        0, PLDM_SUCCESS, 6, 9, reinterpret_cast<uint8_t*>(&pendingValue),
+        0, PLDM_SUCCESS, 8, 9, reinterpret_cast<uint8_t*>(&pendingValue),
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         reinterpret_cast<uint8_t*>(&presentValue), response,
         responseMsg.size() - hdrSize);
@@ -3266,6 +3266,158 @@ TEST(GetNumericEffecterValue, testBadDecodeResponse)
         &reteffecter_dataSize, &reteffecter_operState, retpendingValue,
         retpresentValue);
 
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+}
+
+TEST(GetNumericEffecterValue, testGoodEncodeResponse64)
+{
+    uint8_t completionCode = 0;
+    uint8_t effecter_dataSize = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint8_t effecter_operState = EFFECTER_OPER_STATE_ENABLED_NOUPDATEPENDING;
+    uint64_t pendingValue = 0x12345678abcdef11;
+    uint64_t presentValue = 0xabcdef1112345678;
+    uint64_t val_pending;
+    uint64_t val_present;
+
+    std::array<uint8_t,
+               hdrSize + PLDM_GET_NUMERIC_EFFECTER_VALUE_MIN_RESP_BYTES + 14>
+        responseMsg{};
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto response = reinterpret_cast<pldm_msg*>(responseMsg.data());
+
+    auto rc = encode_get_numeric_effecter_value_resp(
+        0, completionCode, effecter_dataSize, effecter_operState,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<uint8_t*>(&pendingValue),
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<uint8_t*>(&presentValue), response,
+        responseMsg.size() - hdrSize);
+
+    struct pldm_get_numeric_effecter_value_resp* resp =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_get_numeric_effecter_value_resp*>(
+            response->payload);
+
+    memcpy(&val_pending, &resp->pending_and_present_values[0],
+           sizeof(val_pending));
+    val_pending = le64toh(val_pending);
+    memcpy(&val_present, &resp->pending_and_present_values[8],
+           sizeof(val_present));
+    val_present = le64toh(val_present);
+
+    EXPECT_EQ(rc, PLDM_SUCCESS);
+    EXPECT_EQ(effecter_dataSize, resp->effecter_data_size);
+    EXPECT_EQ(effecter_operState, resp->effecter_oper_state);
+    EXPECT_EQ(pendingValue, val_pending);
+    EXPECT_EQ(presentValue, val_present);
+}
+
+TEST(GetNumericEffecterValue, testGoodDecodeResponse64)
+{
+    std::array<uint8_t,
+               hdrSize + PLDM_GET_NUMERIC_EFFECTER_VALUE_MIN_RESP_BYTES + 14>
+        responseMsg{};
+
+    uint8_t completionCode = 0;
+    uint8_t effecter_dataSize = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint8_t effecter_operState = EFFECTER_OPER_STATE_ENABLED_NOUPDATEPENDING;
+    uint64_t pendingValue = 0x8765432111fedcba;
+    uint64_t presentValue = 0x11fedcba87654321;
+
+    uint8_t retcompletionCode;
+    uint8_t reteffecter_dataSize;
+    uint8_t reteffecter_operState;
+    uint8_t retpendingValue[8];
+    uint8_t retpresentValue[8];
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto response = reinterpret_cast<pldm_msg*>(responseMsg.data());
+    struct pldm_get_numeric_effecter_value_resp* resp =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_get_numeric_effecter_value_resp*>(
+            response->payload);
+
+    resp->completion_code = completionCode;
+    resp->effecter_data_size = effecter_dataSize;
+    resp->effecter_oper_state = effecter_operState;
+
+    uint64_t pendingValue_le = htole64(pendingValue);
+    memcpy(resp->pending_and_present_values, &pendingValue_le,
+           sizeof(pendingValue_le));
+    uint64_t presentValue_le = htole64(presentValue);
+    memcpy(&resp->pending_and_present_values[8], &presentValue_le,
+           sizeof(presentValue_le));
+
+    auto rc = decode_get_numeric_effecter_value_resp(
+        response, responseMsg.size() - hdrSize, &retcompletionCode,
+        &reteffecter_dataSize, &reteffecter_operState, retpendingValue,
+        retpresentValue);
+
+    EXPECT_EQ(rc, PLDM_SUCCESS);
+    EXPECT_EQ(completionCode, retcompletionCode);
+    EXPECT_EQ(effecter_dataSize, reteffecter_dataSize);
+    EXPECT_EQ(effecter_operState, reteffecter_operState);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    EXPECT_EQ(pendingValue, *(reinterpret_cast<uint64_t*>(retpendingValue)));
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    EXPECT_EQ(presentValue, *(reinterpret_cast<uint64_t*>(retpresentValue)));
+}
+
+TEST(GetNumericEffecterValue, testBadDecodeResponse64)
+{
+    std::array<uint8_t,
+               hdrSize + PLDM_GET_NUMERIC_EFFECTER_VALUE_MIN_RESP_BYTES + 21>
+        responseMsg{};
+
+    auto rc = decode_get_numeric_effecter_value_resp(
+        nullptr, responseMsg.size() - hdrSize, nullptr, nullptr, nullptr,
+        nullptr, nullptr);
+
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+
+    uint8_t completionCode = 0;
+    uint8_t effecter_dataSize = PLDM_EFFECTER_DATA_SIZE_SINT16;
+    uint8_t effecter_operState = EFFECTER_OPER_STATE_DISABLED;
+    uint64_t pendingValue = 0x12345678abcdef11;
+    uint64_t presentValue = 0xabcdef1112345678;
+
+    uint8_t retcompletionCode;
+    uint8_t reteffecter_dataSize;
+    uint8_t reteffecter_operState;
+    uint8_t retpendingValue[8];
+    uint8_t retpresentValue[8];
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto response = reinterpret_cast<pldm_msg*>(responseMsg.data());
+    struct pldm_get_numeric_effecter_value_resp* resp =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_get_numeric_effecter_value_resp*>(
+            response->payload);
+
+    resp->completion_code = completionCode;
+    resp->effecter_data_size = effecter_dataSize;
+    resp->effecter_oper_state = effecter_operState;
+
+    uint16_t pendingValue_le = htole64(pendingValue);
+    memcpy(resp->pending_and_present_values, &pendingValue_le,
+           sizeof(pendingValue_le));
+    uint16_t presentValue_le = htole64(presentValue);
+    memcpy(&resp->pending_and_present_values[8], &presentValue_le,
+           sizeof(presentValue_le));
+
+    rc = decode_get_numeric_effecter_value_resp(
+        response, responseMsg.size() - hdrSize, &retcompletionCode,
+        &reteffecter_dataSize, &reteffecter_operState, retpendingValue,
+        retpresentValue);
+
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+
+    reteffecter_dataSize = 9;
+    reteffecter_operState = EFFECTER_OPER_STATE_DISABLED;
+
+    rc = decode_get_numeric_effecter_value_resp(
+        response, responseMsg.size() - hdrSize, nullptr, &reteffecter_dataSize, &reteffecter_operState,
+        nullptr, nullptr);
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
 }
 


### PR DESCRIPTION
Added an API for encoding/decoding 64-bit length functions for

GetSensorReading requests and responses as per DSP0248 v1.3 section 18.2
SetNumericEffecterValue requests and responses as per DSP0248 v1.3 section 22.2
GetNumericEffecterValue requests and responses as per DSP0248 v1.3 section 22.3
