### PR TITLE
RDE: Add RDEMultipartReceive cmd support

### DIFF
--- a/include/libpldm/platform.h
+++ b/include/libpldm/platform.h
@@ -44,6 +44,7 @@ enum pldm_platform_transfer_flag {
 
 #define PLDM_SET_NUMERIC_EFFECTER_VALUE_RESP_BYTES    1
 #define PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES 4
+#define PLDM_SET_NUMERIC_EFFECTER_VALUE_MAX_REQ_BYTES 7
 
 #define PLDM_GET_PDR_REQ_BYTES 13
 
@@ -72,8 +73,10 @@ enum pldm_platform_transfer_flag {
 /* Minimum response length */
 #define PLDM_GET_PDR_MIN_RESP_BYTES		       12
 #define PLDM_GET_NUMERIC_EFFECTER_VALUE_MIN_RESP_BYTES 5
+#define PLDM_GET_NUMERIC_EFFECTER_VALUE_MAX_RESP_BYTES 14
 #define PLDM_GET_STATE_EFFECTER_STATES_MIN_RESP_BYTES  2
 #define PLDM_GET_SENSOR_READING_MIN_RESP_BYTES	       8
+#define PLDM_GET_SENSOR_READING_MAX_RESP_BYTES	       7
 #define PLDM_GET_STATE_SENSOR_READINGS_MIN_RESP_BYTES  2
 #define PLDM_GET_PDR_REPOSITORY_INFO_RESP_BYTES	       41
 
@@ -152,6 +155,9 @@ enum pldm_platform_transfer_flag {
 #define PLDM_GET_EFFECTER_STATE_FIELD_COUNT_MIN 1
 #define PLDM_GET_EFFECTER_STATE_FIELD_COUNT_MAX 8
 
+/* Effecter value bounds */
+#define PLDM_EFFECTER_DATA_SIZE_MAX 8
+
 /* Container ID */
 /** @brief Table 2 - Parts of the Entity Identification Information format in
  *         PLDM Platform and Control spec, DSP0248 v1.2.2. "If this value is
@@ -165,7 +171,9 @@ enum pldm_effecter_data_size {
 	PLDM_EFFECTER_DATA_SIZE_UINT16,
 	PLDM_EFFECTER_DATA_SIZE_SINT16,
 	PLDM_EFFECTER_DATA_SIZE_UINT32,
-	PLDM_EFFECTER_DATA_SIZE_SINT32
+	PLDM_EFFECTER_DATA_SIZE_SINT32,
+	PLDM_EFFECTER_DATA_SIZE_UINT64,
+	PLDM_EFFECTER_DATA_SIZE_SINT64
 };
 
 enum pldm_range_field_format {
@@ -175,9 +183,11 @@ enum pldm_range_field_format {
 	PLDM_RANGE_FIELD_FORMAT_SINT16,
 	PLDM_RANGE_FIELD_FORMAT_UINT32,
 	PLDM_RANGE_FIELD_FORMAT_SINT32,
-	PLDM_RANGE_FIELD_FORMAT_REAL32
+	PLDM_RANGE_FIELD_FORMAT_REAL32,
+	PLDM_RANGE_FIELD_FORMAT_UINT64,
+	PLDM_RANGE_FIELD_FORMAT_SINT64
 };
-#define PLDM_RANGE_FIELD_FORMAT_MAX PLDM_RANGE_FIELD_FORMAT_REAL32
+#define PLDM_RANGE_FIELD_FORMAT_MAX PLDM_RANGE_FIELD_FORMAT_SINT64
 
 enum set_request { PLDM_NO_CHANGE = 0x00, PLDM_REQUEST_SET = 0x01 };
 
@@ -386,9 +396,11 @@ enum pldm_sensor_readings_data_type {
 	PLDM_SENSOR_DATA_SIZE_UINT16,
 	PLDM_SENSOR_DATA_SIZE_SINT16,
 	PLDM_SENSOR_DATA_SIZE_UINT32,
-	PLDM_SENSOR_DATA_SIZE_SINT32
+	PLDM_SENSOR_DATA_SIZE_SINT32,
+	PLDM_SENSOR_DATA_SIZE_UINT64,
+	PLDM_SENSOR_DATA_SIZE_SINT64
 };
-#define PLDM_SENSOR_DATA_SIZE_MAX PLDM_SENSOR_DATA_SIZE_SINT32
+#define PLDM_SENSOR_DATA_SIZE_MAX PLDM_SENSOR_DATA_SIZE_SINT64
 
 /** @brief PLDM PlatformEventMessage response status
  */
@@ -735,6 +747,8 @@ typedef union {
 	int16_t value_s16;
 	uint32_t value_u32;
 	int32_t value_s32;
+	uint64_t value_u64;
+	int64_t value_s64;
 } union_effecter_data_size;
 
 /** @union union_range_field_format
@@ -751,6 +765,8 @@ typedef union {
 	uint32_t value_u32;
 	int32_t value_s32;
 	real32_t value_f32;
+	uint64_t value_u64;
+	int64_t value_s64;
 } union_range_field_format;
 
 /** @struct pldm_numeric_effecter_value_pdr
@@ -808,6 +824,8 @@ typedef union {
 	int16_t value_s16;
 	uint32_t value_u32;
 	int32_t value_s32;
+	uint64_t value_u64;
+	int64_t value_s64;
 } union_sensor_data_size;
 
 /** @struct pldm_value_pdr_hdr
@@ -1356,11 +1374,10 @@ struct pldm_get_sensor_reading_resp {
  * 				requested.
  *  @return pldm_completion_codes
  */
-int decode_set_numeric_effecter_value_req(const struct pldm_msg *msg,
-					  size_t payload_length,
-					  uint16_t *effecter_id,
-					  uint8_t *effecter_data_size,
-					  uint8_t effecter_value[4]);
+int decode_set_numeric_effecter_value_req(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint16_t *effecter_id, uint8_t *effecter_data_size,
+	uint8_t effecter_value[PLDM_EFFECTER_DATA_SIZE_MAX]);
 
 /** @brief Create a PLDM response message for SetNumericEffecterValue
  *

--- a/include/libpldm/platform.h
+++ b/include/libpldm/platform.h
@@ -927,7 +927,7 @@ struct pldm_entity_auxiliary_names_pdr {
 	char auxiliary_name_data[]
 		__attribute__((aligned(alignof(pldm_utf16be))));
 #else
-#error("__has_attribute() support is required to uphold runtime safety")
+#error ("__has_attribute() support is required to uphold runtime safety")
 #endif
 #endif
 };

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ project(
         'tests': not meson.is_subproject(),
     },
     version: '0.12.0',
-    meson_version: '>=1.4.0',
+    meson_version: '>=1.3.0',
 )
 
 if get_option('tests')
@@ -70,7 +70,7 @@ endif
 
 config = configure_file(output: 'config.h', configuration: conf)
 
-add_project_arguments('-include', config.full_path(), language: 'c')
+add_project_arguments('-include', '@0@'.format(config), language: 'c')
 
 libpldm_include_dir = include_directories('include', is_system: true)
 

--- a/src/dsp/platform.c
+++ b/src/dsp/platform.c
@@ -718,11 +718,10 @@ int decode_get_pdr_resp_safe(const struct pldm_msg *msg, size_t payload_length,
 }
 
 LIBPLDM_ABI_STABLE
-int decode_set_numeric_effecter_value_req(const struct pldm_msg *msg,
-					  size_t payload_length,
-					  uint16_t *effecter_id,
-					  uint8_t *effecter_data_size,
-					  uint8_t effecter_value[4])
+int decode_set_numeric_effecter_value_req(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint16_t *effecter_id, uint8_t *effecter_data_size,
+	uint8_t effecter_value[PLDM_EFFECTER_DATA_SIZE_MAX])
 {
 	PLDM_MSGBUF_DEFINE_P(buf);
 	int rc;
@@ -745,7 +744,7 @@ int decode_set_numeric_effecter_value_req(const struct pldm_msg *msg,
 		return pldm_msgbuf_discard(buf, PLDM_ERROR_INVALID_DATA);
 	}
 
-	if (*effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT32) {
+	if (*effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT64) {
 		return pldm_msgbuf_discard(buf, PLDM_ERROR_INVALID_DATA);
 	}
 
@@ -802,7 +801,7 @@ int encode_set_numeric_effecter_value_req(uint8_t instance_id,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT32) {
+	if (effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT64) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
@@ -847,6 +846,17 @@ int encode_set_numeric_effecter_value_req(uint8_t instance_id,
 		uint32_t val = *(uint32_t *)(effecter_value);
 		val = htole32(val);
 		memcpy(request->effecter_value, &val, sizeof(uint32_t));
+	} else if (effecter_data_size == PLDM_EFFECTER_DATA_SIZE_UINT64 ||
+		   effecter_data_size == PLDM_EFFECTER_DATA_SIZE_SINT64) {
+		if (payload_length !=
+		    PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES +
+			    PLDM_SET_NUMERIC_EFFECTER_VALUE_MAX_REQ_BYTES) {
+			return PLDM_ERROR_INVALID_LENGTH;
+		}
+
+		uint64_t val = *(uint64_t *)(effecter_value);
+		val = htole64(val);
+		memcpy(request->effecter_value, &val, sizeof(uint64_t));
 	}
 
 	request->effecter_id = htole16(effecter_id);
@@ -1934,7 +1944,7 @@ int encode_get_numeric_effecter_value_resp(
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT32) {
+	if (effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT64) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
@@ -2000,7 +2010,24 @@ int encode_get_numeric_effecter_value_resp(
 		memcpy((response->pending_and_present_values +
 			sizeof(uint32_t)),
 		       &val_present, sizeof(uint32_t));
+	} else if (effecter_data_size == PLDM_EFFECTER_DATA_SIZE_UINT64 ||
+		   effecter_data_size == PLDM_EFFECTER_DATA_SIZE_SINT64) {
+		if (payload_length !=
+		    PLDM_GET_NUMERIC_EFFECTER_VALUE_MIN_RESP_BYTES +
+			    PLDM_GET_NUMERIC_EFFECTER_VALUE_MAX_RESP_BYTES) {
+			return PLDM_ERROR_INVALID_LENGTH;
+		}
+		uint64_t val_pending = *(uint64_t *)pending_value;
+		val_pending = htole64(val_pending);
+		memcpy(response->pending_and_present_values, &val_pending,
+		       sizeof(uint64_t));
+		uint64_t val_present = *(uint64_t *)present_value;
+		val_present = htole64(val_present);
+		memcpy((response->pending_and_present_values +
+			sizeof(uint64_t)),
+		       &val_present, sizeof(uint64_t));
 	}
+
 	return PLDM_SUCCESS;
 }
 
@@ -2072,7 +2099,7 @@ int decode_get_numeric_effecter_value_resp(const struct pldm_msg *msg,
 		return pldm_xlate_errno(pldm_msgbuf_discard(buf, rc));
 	}
 
-	if (*effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT32) {
+	if (*effecter_data_size > PLDM_EFFECTER_DATA_SIZE_SINT64) {
 		return pldm_msgbuf_discard(buf, PLDM_ERROR_INVALID_DATA);
 	}
 
@@ -2364,7 +2391,7 @@ int decode_get_sensor_reading_resp(
 		return pldm_xlate_errno(pldm_msgbuf_discard(buf, rc));
 	}
 
-	if (*sensor_data_size > PLDM_SENSOR_DATA_SIZE_SINT32) {
+	if (*sensor_data_size > PLDM_SENSOR_DATA_SIZE_SINT64) {
 		return pldm_msgbuf_discard(buf, PLDM_ERROR_INVALID_DATA);
 	}
 
@@ -2399,7 +2426,7 @@ int encode_get_sensor_reading_resp(uint8_t instance_id, uint8_t completion_code,
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
-	if (sensor_data_size > PLDM_EFFECTER_DATA_SIZE_SINT32) {
+	if (sensor_data_size > PLDM_EFFECTER_DATA_SIZE_SINT64) {
 		return PLDM_ERROR_INVALID_DATA;
 	}
 
@@ -2451,6 +2478,16 @@ int encode_get_sensor_reading_resp(uint8_t instance_id, uint8_t completion_code,
 		uint32_t val = *(uint32_t *)present_reading;
 		val = htole32(val);
 		memcpy(response->present_reading, &val, 4);
+	} else if (sensor_data_size == PLDM_EFFECTER_DATA_SIZE_UINT64 ||
+		   sensor_data_size == PLDM_EFFECTER_DATA_SIZE_SINT64) {
+		if (payload_length !=
+		    PLDM_GET_SENSOR_READING_MIN_RESP_BYTES +
+			    PLDM_GET_SENSOR_READING_MAX_RESP_BYTES) {
+			return PLDM_ERROR_INVALID_LENGTH;
+		}
+		uint64_t val = *(uint64_t *)present_reading;
+		val = htole64(val);
+		memcpy(response->present_reading, &val, 8);
 	}
 
 	return PLDM_SUCCESS;

--- a/src/meson.build
+++ b/src/meson.build
@@ -103,7 +103,7 @@ if get_option('tests')
                     '-new',
                     '@INPUT1@',
                 ],
-                build_by_default: true,
+                build_by_default: false,
             )
         endif
     endif

--- a/src/msgbuf.h
+++ b/src/msgbuf.h
@@ -576,6 +576,72 @@ pldm__msgbuf_extract_real32(struct pldm_msgbuf *ctx, void *dst)
 	return pldm__msgbuf_invalidate(ctx);
 }
 
+#define pldm_msgbuf_extract_uint64(ctx, dst)                                   \
+	pldm_msgbuf_extract_typecheck(uint64_t, pldm__msgbuf_extract_uint64,   \
+				      dst, ctx, (void *)&(dst))
+LIBPLDM_CC_NONNULL
+LIBPLDM_CC_ALWAYS_INLINE int
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+pldm__msgbuf_extract_uint64(struct pldm_msgbuf *ctx, void *dst)
+{
+	uint64_t ldst;
+
+	static_assert(
+		// NOLINTNEXTLINE(bugprone-sizeof-expression)
+		sizeof(ldst) < INTMAX_MAX,
+		"The following addition may not uphold the runtime assertion");
+
+	if (ctx->remaining >= (intmax_t)sizeof(ldst)) {
+		assert(ctx->cursor);
+		memcpy(&ldst, ctx->cursor, sizeof(ldst));
+		ldst = le64toh(ldst);
+		memcpy(dst, &ldst, sizeof(ldst));
+		ctx->cursor += sizeof(ldst);
+		ctx->remaining -= sizeof(ldst);
+		return 0;
+	}
+
+	if (ctx->remaining > INTMAX_MIN + (intmax_t)sizeof(ldst)) {
+		ctx->remaining -= sizeof(ldst);
+		return -EOVERFLOW;
+	}
+
+	return pldm__msgbuf_invalidate(ctx);
+}
+
+#define pldm_msgbuf_extract_int64(ctx, dst)                                    \
+	pldm_msgbuf_extract_typecheck(int64_t, pldm__msgbuf_extract_int64,     \
+				      dst, ctx, (void *)&(dst))
+LIBPLDM_CC_NONNULL
+LIBPLDM_CC_ALWAYS_INLINE int
+// NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
+pldm__msgbuf_extract_int64(struct pldm_msgbuf *ctx, void *dst)
+{
+	int64_t ldst;
+
+	static_assert(
+		// NOLINTNEXTLINE(bugprone-sizeof-expression)
+		sizeof(ldst) < INTMAX_MAX,
+		"The following addition may not uphold the runtime assertion");
+
+	if (ctx->remaining >= (intmax_t)sizeof(ldst)) {
+		assert(ctx->cursor);
+		memcpy(&ldst, ctx->cursor, sizeof(ldst));
+		ldst = le64toh(ldst);
+		memcpy(dst, &ldst, sizeof(ldst));
+		ctx->cursor += sizeof(ldst);
+		ctx->remaining -= sizeof(ldst);
+		return 0;
+	}
+
+	if (ctx->remaining > INTMAX_MIN + (intmax_t)sizeof(ldst)) {
+		ctx->remaining -= sizeof(ldst);
+		return -EOVERFLOW;
+	}
+
+	return pldm__msgbuf_invalidate(ctx);
+}
+
 /**
  * Extract the field at the msgbuf cursor into the lvalue named by dst.
  *
@@ -593,7 +659,9 @@ pldm__msgbuf_extract_real32(struct pldm_msgbuf *ctx, void *dst)
 		int16_t: pldm__msgbuf_extract_int16,                           \
 		uint32_t: pldm__msgbuf_extract_uint32,                         \
 		int32_t: pldm__msgbuf_extract_int32,                           \
-		real32_t: pldm__msgbuf_extract_real32)(ctx, (void *)&(dst))
+		real32_t: pldm__msgbuf_extract_real32,                         \
+		uint64_t: pldm__msgbuf_extract_uint64,                         \
+		int64_t: pldm__msgbuf_extract_int64)(ctx, (void *)&(dst))
 
 /**
  * Extract the field at the msgbuf cursor into the object pointed-to by dst.
@@ -612,7 +680,9 @@ pldm__msgbuf_extract_real32(struct pldm_msgbuf *ctx, void *dst)
 		int16_t *: pldm__msgbuf_extract_int16,                         \
 		uint32_t *: pldm__msgbuf_extract_uint32,                       \
 		int32_t *: pldm__msgbuf_extract_int32,                         \
-		real32_t *: pldm__msgbuf_extract_real32)(ctx, dst)
+		real32_t *: pldm__msgbuf_extract_real32,                       \
+		uint64_t *: pldm__msgbuf_extract_uint64,                       \
+		int64_t *: pldm__msgbuf_extract_int64)(ctx, dst)
 
 /**
  * @ref pldm_msgbuf_extract_array
@@ -1500,6 +1570,23 @@ static inline int pldm_msgbuf_typecheck_real32_t(struct pldm_msgbuf *ctx,
 	static_assert(std::is_same<real32_t, T>::value);
 	return pldm__msgbuf_extract_real32(ctx, buf);
 }
+
+template <typename T>
+static inline int pldm_msgbuf_typecheck_uint64_t(struct pldm_msgbuf *ctx,
+						 void *buf)
+{
+	static_assert(std::is_same<uint64_t, T>::value);
+	return pldm__msgbuf_extract_uint64(ctx, buf);
+}
+
+template <typename T>
+static inline int pldm_msgbuf_typecheck_int64_t(struct pldm_msgbuf *ctx,
+						void *buf)
+{
+	static_assert(std::is_same<int64_t, T>::value);
+	return pldm__msgbuf_extract_int64(ctx, buf);
+}
+
 #endif
 
 #endif /* BUF_H */

--- a/src/msgbuf/platform.h
+++ b/src/msgbuf/platform.h
@@ -53,6 +53,10 @@ pldm_msgbuf_extract_sensor_data(struct pldm_msgbuf *ctx,
 		return pldm_msgbuf_extract(ctx, dst->value_u32);
 	case PLDM_SENSOR_DATA_SIZE_SINT32:
 		return pldm_msgbuf_extract(ctx, dst->value_s32);
+	case PLDM_SENSOR_DATA_SIZE_UINT64:
+		return pldm_msgbuf_extract(ctx, dst->value_u64);
+	case PLDM_SENSOR_DATA_SIZE_SINT64:
+		return pldm_msgbuf_extract(ctx, dst->value_s64);
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -81,6 +85,10 @@ pldm_msgbuf_extract_sensor_value(struct pldm_msgbuf *ctx,
 		return pldm__msgbuf_extract_uint32(ctx, val);
 	case PLDM_SENSOR_DATA_SIZE_SINT32:
 		return pldm__msgbuf_extract_int32(ctx, val);
+	case PLDM_SENSOR_DATA_SIZE_UINT64:
+		return pldm__msgbuf_extract_uint64(ctx, val);
+	case PLDM_SENSOR_DATA_SIZE_SINT64:
+		return pldm__msgbuf_extract_int64(ctx, val);
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -122,6 +130,14 @@ LIBPLDM_CC_ALWAYS_INLINE int pldm__msgbuf_extract_range_field_format(
 		return pldm__msgbuf_extract_real32(
 			ctx, ((char *)rff) + offsetof(union_range_field_format,
 						      value_f32));
+	case PLDM_RANGE_FIELD_FORMAT_UINT64:
+		return pldm__msgbuf_extract_uint64(
+			ctx, ((char *)rff) + offsetof(union_range_field_format,
+						      value_u64));
+	case PLDM_RANGE_FIELD_FORMAT_SINT64:
+		return pldm__msgbuf_extract_int64(
+			ctx, ((char *)rff) + offsetof(union_range_field_format,
+						      value_s64));
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -145,6 +161,10 @@ pldm_msgbuf_extract_effecter_value(struct pldm_msgbuf *ctx,
 		return pldm__msgbuf_extract_uint32(ctx, dst);
 	case PLDM_EFFECTER_DATA_SIZE_SINT32:
 		return pldm__msgbuf_extract_int32(ctx, dst);
+	case PLDM_EFFECTER_DATA_SIZE_UINT64:
+		return pldm__msgbuf_extract_uint64(ctx, dst);
+	case PLDM_EFFECTER_DATA_SIZE_SINT64:
+		return pldm__msgbuf_extract_int64(ctx, dst);
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;
@@ -183,6 +203,15 @@ pldm__msgbuf_extract_effecter_data(struct pldm_msgbuf *ctx,
 		return pldm__msgbuf_extract_int32(
 			ctx, ((char *)ed) + offsetof(union_effecter_data_size,
 						     value_s32));
+
+	case PLDM_EFFECTER_DATA_SIZE_UINT64:
+		return pldm__msgbuf_extract_uint64(
+			ctx, ((char *)ed) + offsetof(union_effecter_data_size,
+						     value_u64));
+	case PLDM_EFFECTER_DATA_SIZE_SINT64:
+		return pldm__msgbuf_extract_int64(
+			ctx, ((char *)ed) + offsetof(union_effecter_data_size,
+						     value_s64));
 	}
 
 	return -PLDM_ERROR_INVALID_DATA;

--- a/tests/dsp/firmware_update.cpp
+++ b/tests/dsp/firmware_update.cpp
@@ -2839,7 +2839,7 @@ TEST(RequestUpdate, errorPathEncodeRequest)
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
     maxTransferSize = PLDM_FWUP_BASELINE_TRANSFER_SIZE;
 
-    maxOutstandingTransferReq = PLDM_FWUP_MIN_OUTSTANDING_REQ - 1;
+    maxOutstandingTransferReq = 0;
     rc = encode_request_update_req(
         instanceId, maxTransferSize, numOfComp, maxOutstandingTransferReq,
         pkgDataLen, PLDM_STR_TYPE_ASCII, compImgSetVerStrLen,

--- a/tests/dsp/platform.cpp
+++ b/tests/dsp/platform.cpp
@@ -893,7 +893,7 @@ TEST(SetNumericEffecterValue, testBadEncodeRequest)
     uint16_t effecter_value;
     rc = encode_set_numeric_effecter_value_req(
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-        0, 0, 6, reinterpret_cast<uint8_t*>(&effecter_value), request,
+        0, 0, 8, reinterpret_cast<uint8_t*>(&effecter_value), request,
         PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES);
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
 }
@@ -955,6 +955,110 @@ TEST(SetNumericEffecterValue, testBadEncodeResponse)
     auto rc = encode_set_numeric_effecter_value_resp(
         0, PLDM_SUCCESS, NULL, PLDM_SET_NUMERIC_EFFECTER_VALUE_RESP_BYTES);
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+}
+
+TEST(SetNumericEffecterValue, testGoodDecodeRequest64)
+{
+    std::array<uint8_t,
+               hdrSize + PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES + 7>
+        requestMsg{};
+
+    uint16_t effecter_id = 32768;
+    uint8_t effecter_data_size = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint64_t effecter_value = 0x12345678abcdef11;
+
+    uint16_t reteffecter_id;
+    uint8_t reteffecter_data_size;
+    uint8_t reteffecter_value[8];
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto req = reinterpret_cast<pldm_msg*>(requestMsg.data());
+    struct pldm_set_numeric_effecter_value_req* request =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_set_numeric_effecter_value_req*>(
+            req->payload);
+
+    request->effecter_id = htole16(effecter_id);
+    request->effecter_data_size = effecter_data_size;
+    uint64_t effecter_value_le = htole64(effecter_value);
+    memcpy(request->effecter_value, &effecter_value_le,
+           sizeof(effecter_value_le));
+
+    auto rc = decode_set_numeric_effecter_value_req(
+        req, requestMsg.size() - hdrSize, &reteffecter_id,
+        &reteffecter_data_size, reteffecter_value);
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    uint64_t value = *(reinterpret_cast<uint64_t*>(reteffecter_value));
+    EXPECT_EQ(rc, PLDM_SUCCESS);
+    EXPECT_EQ(reteffecter_id, effecter_id);
+    EXPECT_EQ(reteffecter_data_size, effecter_data_size);
+    EXPECT_EQ(value, effecter_value);
+}
+
+TEST(SetNumericEffecterValue, testBadDecodeRequest64)
+{
+    std::array<uint8_t,
+               hdrSize + PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES + 7>
+        requestMsg{};
+
+    auto rc = decode_set_numeric_effecter_value_req(
+        NULL, requestMsg.size() - hdrSize, NULL, NULL, NULL);
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+
+    uint16_t effecter_id = 0x10;
+    uint8_t effecter_data_size = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint64_t effecter_value = 0x12345678abcdef11;
+
+    uint16_t reteffecter_id;
+    uint8_t reteffecter_data_size;
+    uint8_t reteffecter_value[8];
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto req = reinterpret_cast<pldm_msg*>(requestMsg.data());
+    struct pldm_set_numeric_effecter_value_req* request =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_set_numeric_effecter_value_req*>(
+            req->payload);
+
+    request->effecter_id = effecter_id;
+    request->effecter_data_size = effecter_data_size;
+    memcpy(request->effecter_value, &effecter_value, sizeof(effecter_value));
+
+    rc = decode_set_numeric_effecter_value_req(
+        req, requestMsg.size() - hdrSize - 1, &reteffecter_id,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        &reteffecter_data_size, reinterpret_cast<uint8_t*>(&reteffecter_value));
+    EXPECT_EQ(rc, PLDM_ERROR_INVALID_LENGTH);
+}
+
+TEST(SetNumericEffecterValue, testGoodEncodeRequest64)
+{
+    uint16_t effecter_id = 0;
+    uint8_t effecter_data_size = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint64_t effecter_value = 0x12345678abcdef11;
+
+    std::vector<uint8_t> requestMsg(
+        hdrSize + PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES + 7);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto request = reinterpret_cast<pldm_msg*>(requestMsg.data());
+
+    auto rc = encode_set_numeric_effecter_value_req(
+        0, effecter_id, effecter_data_size,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<uint8_t*>(&effecter_value), request,
+        PLDM_SET_NUMERIC_EFFECTER_VALUE_MIN_REQ_BYTES + 7);
+    EXPECT_EQ(rc, PLDM_SUCCESS);
+
+    struct pldm_set_numeric_effecter_value_req* req =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_set_numeric_effecter_value_req*>(
+            request->payload);
+    EXPECT_EQ(effecter_id, req->effecter_id);
+    EXPECT_EQ(effecter_data_size, req->effecter_data_size);
+    uint64_t* val = (uint64_t*)req->effecter_value;
+    *val = le64toh(*val);
+    EXPECT_EQ(effecter_value, *val);
 }
 
 TEST(GetStateSensorReadings, testGoodEncodeResponse)

--- a/tests/dsp/platform.cpp
+++ b/tests/dsp/platform.cpp
@@ -3696,7 +3696,7 @@ TEST(GetSensorReading, testBadEncodeResponse)
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
 
     rc = encode_get_sensor_reading_resp(
-        0, PLDM_SUCCESS, 6, 1, 1, 1, 1, 1,
+        0, PLDM_SUCCESS, 8, 1, 1, 1, 1, 1,
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         reinterpret_cast<uint8_t*>(&presentReading), response,
         responseMsg.size() - hdrSize);
@@ -3826,6 +3826,109 @@ TEST(GetSensorReading, testBadDecodeResponse)
         &retevent_state, reinterpret_cast<uint8_t*>(&retpresentReading));
 
     EXPECT_EQ(rc, PLDM_ERROR_INVALID_DATA);
+}
+
+TEST(GetSensorReading, testGoodEncodeResponse64)
+{
+    std::array<uint8_t, hdrSize + PLDM_GET_SENSOR_READING_MIN_RESP_BYTES + 7>
+        responseMsg{};
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto response = reinterpret_cast<pldm_msg*>(responseMsg.data());
+
+    uint8_t completionCode = 0;
+    uint8_t sensor_dataSize = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint8_t sensor_operationalState = PLDM_SENSOR_ENABLED;
+    uint8_t sensor_event_messageEnable = PLDM_NO_EVENT_GENERATION;
+    uint8_t presentState = PLDM_SENSOR_NORMAL;
+    uint8_t previousState = PLDM_SENSOR_WARNING;
+    uint8_t eventState = PLDM_SENSOR_UPPERWARNING;
+    uint64_t presentReading = 0x12345678abcdef11;
+
+    auto rc = encode_get_sensor_reading_resp(
+        0, completionCode, sensor_dataSize, sensor_operationalState,
+        sensor_event_messageEnable, presentState, previousState, eventState,
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<uint8_t*>(&presentReading), response,
+        responseMsg.size() - hdrSize);
+
+    struct pldm_get_sensor_reading_resp* resp =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_get_sensor_reading_resp*>(
+            response->payload);
+
+    EXPECT_EQ(rc, PLDM_SUCCESS);
+    EXPECT_EQ(completionCode, resp->completion_code);
+    EXPECT_EQ(sensor_dataSize, resp->sensor_data_size);
+    EXPECT_EQ(sensor_operationalState, resp->sensor_operational_state);
+    EXPECT_EQ(sensor_event_messageEnable, resp->sensor_event_message_enable);
+    EXPECT_EQ(presentState, resp->present_state);
+    EXPECT_EQ(previousState, resp->previous_state);
+    EXPECT_EQ(eventState, resp->event_state);
+    EXPECT_EQ(presentReading,
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+              *(reinterpret_cast<uint64_t*>(&resp->present_reading[0])));
+}
+
+TEST(GetSensorReading, testGoodDecodeResponse64)
+{
+    std::array<uint8_t, hdrSize + PLDM_GET_SENSOR_READING_MIN_RESP_BYTES + 7>
+        responseMsg{};
+
+    uint8_t completionCode = 0;
+    uint8_t sensor_dataSize = PLDM_EFFECTER_DATA_SIZE_UINT64;
+    uint8_t sensor_operationalState = PLDM_SENSOR_STATUSUNKOWN;
+    uint8_t sensor_event_messageEnable = PLDM_EVENTS_ENABLED;
+    uint8_t presentState = PLDM_SENSOR_CRITICAL;
+    uint8_t previousState = PLDM_SENSOR_UPPERCRITICAL;
+    uint8_t eventState = PLDM_SENSOR_WARNING;
+    uint64_t presentReading = 0x12345678abcdef11;
+
+    uint8_t retcompletionCode;
+    uint8_t retsensor_dataSize = PLDM_SENSOR_DATA_SIZE_UINT64;
+    uint8_t retsensor_operationalState;
+    uint8_t retsensor_event_messageEnable;
+    uint8_t retpresentState;
+    uint8_t retpreviousState;
+    uint8_t reteventState;
+    uint8_t retpresentReading[8];
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    auto response = reinterpret_cast<pldm_msg*>(responseMsg.data());
+    struct pldm_get_sensor_reading_resp* resp =
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+        reinterpret_cast<struct pldm_get_sensor_reading_resp*>(
+            response->payload);
+
+    resp->completion_code = completionCode;
+    resp->sensor_data_size = sensor_dataSize;
+    resp->sensor_operational_state = sensor_operationalState;
+    resp->sensor_event_message_enable = sensor_event_messageEnable;
+    resp->present_state = presentState;
+    resp->previous_state = previousState;
+    resp->event_state = eventState;
+
+    uint64_t presentReading_le = htole64(presentReading);
+    memcpy(resp->present_reading, &presentReading_le,
+           sizeof(presentReading_le));
+
+    auto rc = decode_get_sensor_reading_resp(
+        response, responseMsg.size() - hdrSize, &retcompletionCode,
+        &retsensor_dataSize, &retsensor_operationalState,
+        &retsensor_event_messageEnable, &retpresentState, &retpreviousState,
+        &reteventState, retpresentReading);
+
+    EXPECT_EQ(rc, PLDM_SUCCESS);
+    EXPECT_EQ(completionCode, retcompletionCode);
+    EXPECT_EQ(sensor_dataSize, retsensor_dataSize);
+    EXPECT_EQ(sensor_operationalState, retsensor_operationalState);
+    EXPECT_EQ(sensor_event_messageEnable, retsensor_event_messageEnable);
+    EXPECT_EQ(presentState, retpresentState);
+    EXPECT_EQ(previousState, retpreviousState);
+    EXPECT_EQ(eventState, reteventState);
+    EXPECT_EQ(presentReading,
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+              *(reinterpret_cast<uint64_t*>(retpresentReading)));
 }
 
 TEST(SetEventReceiver, testGoodEncodeRequest)

--- a/tests/dsp/platform.cpp
+++ b/tests/dsp/platform.cpp
@@ -1056,9 +1056,11 @@ TEST(SetNumericEffecterValue, testGoodEncodeRequest64)
             request->payload);
     EXPECT_EQ(effecter_id, req->effecter_id);
     EXPECT_EQ(effecter_data_size, req->effecter_data_size);
-    uint64_t* val = (uint64_t*)req->effecter_value;
-    *val = le64toh(*val);
-    EXPECT_EQ(effecter_value, *val);
+
+    uint64_t val_le = 0;
+    std::memcpy(&val_le, req->effecter_value, sizeof(val_le));
+    uint64_t val = le64toh(val_le);
+    EXPECT_EQ(effecter_value, val);
 }
 
 TEST(GetStateSensorReadings, testGoodEncodeResponse)
@@ -3865,9 +3867,11 @@ TEST(GetSensorReading, testGoodEncodeResponse64)
     EXPECT_EQ(presentState, resp->present_state);
     EXPECT_EQ(previousState, resp->previous_state);
     EXPECT_EQ(eventState, resp->event_state);
-    EXPECT_EQ(presentReading,
-              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-              *(reinterpret_cast<uint64_t*>(&resp->present_reading[0])));
+
+    uint64_t val64 = 0;
+    std::memcpy(&val64, &resp->present_reading[0], sizeof(val64));
+    val64 = le64toh(val64);
+    EXPECT_EQ(presentReading, val64);
 }
 
 TEST(GetSensorReading, testGoodDecodeResponse64)


### PR DESCRIPTION
Add encode and decope APIs for RDEMultipartReceive command.

Tests:
Unit tested passed.

    [----------] 3 tests from RDEMultipartReceiveTest
    [ RUN      ] RDEMultipartReceiveTest.EncodeDecodeRequestSuccess
    [       OK ] RDEMultipartReceiveTest.EncodeDecodeRequestSuccess (0 ms)
    [ RUN      ] RDEMultipartReceiveTest.EncodeDecodeResoponseSuccess
    [       OK ] RDEMultipartReceiveTest.EncodeDecodeResoponseSuccess (0 ms)
    [ RUN      ] RDEMultipartReceiveTest.EncodeDecodeResoponseWithChecksumSuccess
    [       OK ] RDEMultipartReceiveTest.EncodeDecodeResoponseWithChecksumSuccess (0 ms)
    [----------] 3 tests from RDEMultipartReceiveTest (0 ms total)

    Signed-off-by: Raja Sekhar Reddy Gade <rajagade@amd.com>