### PR TITLE
rde: Discovery Commands support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Change categories:
 - rde: Add NegotiateMediumParameters support
 - rde: Add GetSchemaDictionary support
 - rde: Add GetSchemaURI support
+- rde: Add GetResourceETag support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Change categories:
 - rde: Add NegotiateRedfishParameters support
 - rde: Add NegotiateMediumParameters support
 - rde: Add GetSchemaDictionary support
+- rde: Add GetSchemaURI support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Change categories:
 - Support for building the documentation with doxygen
 - base: Add encode req & decode resp for MultipartReceive
 - pdr: Add pldm_file_descriptor_pdr struct
+- rde: Add NegotiateRedfishParameters support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Change categories:
 - pdr: Add pldm_file_descriptor_pdr struct
 - rde: Add NegotiateRedfishParameters support
 - rde: Add NegotiateMediumParameters support
+- rde: Add GetSchemaDictionary support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Change categories:
 - base: Add encode req & decode resp for MultipartReceive
 - pdr: Add pldm_file_descriptor_pdr struct
 - rde: Add NegotiateRedfishParameters support
+- rde: Add NegotiateMediumParameters support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/include/libpldm/meson.build
+++ b/include/libpldm/meson.build
@@ -15,6 +15,7 @@ libpldm_headers = files(
     'platform.h',
     'pldm.h',
     'pldm_types.h',
+    'rde.h',
     'state_set.h',
     'states.h',
     'transport.h',

--- a/include/libpldm/rde.h
+++ b/include/libpldm/rde.h
@@ -13,9 +13,13 @@ extern "C" {
 /* Response lengths are inclusive of completion code */
 #define PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES	    3
 #define PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_RESP_MIN_SIZE 12
+#define PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES	    4
+#define PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES	    5
+#define PLDM_RDE_MIN_TRANSFER_SIZE_BYTES		    64
 
 enum pldm_rde_commands {
 	PLDM_NEGOTIATE_REDFISH_PARAMETERS = 0x01,
+	PLDM_NEGOTIATE_MEDIUM_PARAMETERS = 0x02,
 };
 
 enum pldm_rde_varstring_format {
@@ -154,6 +158,59 @@ int decode_negotiate_redfish_parameters_resp(
 	bitfield16_t *device_feature_support,
 	uint32_t *device_configuration_signature,
 	struct pldm_rde_varstring *provider_name);
+
+/**
+ * @brief Encode NegotiateMediumParameters request.
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] mc_max_transfer_size - Maximum amount of data the MC can
+ * support for a single message transfer.
+ * @param[out] msg - Request message.
+ * @return pldm_completion_codes.
+ */
+int encode_negotiate_medium_parameters_req(uint8_t instance_id,
+					   uint32_t mc_max_transfer_size,
+					   struct pldm_msg *msg);
+
+/**
+ * @brief Decode NegotiateMediumParameters request.
+ *
+ * @param[in] msg - Request message.
+ * @param[out] mc_max_transfer_size - Pointer to a uint32_t variable.
+ * @return pldm_completion_codes.
+ */
+int decode_negotiate_medium_parameters_req(const struct pldm_msg *msg,
+					   uint32_t *mc_max_transfer_size);
+
+/**
+ * @brief Decode Negotiate Medium Parameters response
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] completion_code - PLDM completion code.
+ * @param[in] device_max_transfer_size - The maximum number of bytes that
+ * the RDE Device can support in a chunk for a single message transfer
+ * @param[in] payload_length - Length of the encoded payload segment.
+ * @param[out] msg - Response message will be written to this.
+ * @return pldm_completion_codes.
+ */
+int encode_negotiate_medium_parameters_resp(uint8_t instance_id,
+					    uint8_t completion_code,
+					    uint32_t device_max_transfer_size,
+					    size_t payload_length,
+					    struct pldm_msg *msg);
+
+/**
+ * @brief Decode Negotiate Medium Parameters response
+ *
+ * @param[in] msg: PLDM Msg byte array received from the responder
+ * @param[in] payload_length: Length of the payload
+ * @param[out] completion_code: Completion code as set by the responder
+ * @param[out] device_max_transfer_size: Pointer to a uint32_t variable
+ */
+int decode_negotiate_medium_parameters_resp(const struct pldm_msg *msg,
+					    size_t payload_length,
+					    uint8_t *completion_code,
+					    uint32_t *device_max_transfer_size);
 
 #ifdef __cplusplus
 }

--- a/include/libpldm/rde.h
+++ b/include/libpldm/rde.h
@@ -16,10 +16,13 @@ extern "C" {
 #define PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES	    4
 #define PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES	    5
 #define PLDM_RDE_MIN_TRANSFER_SIZE_BYTES		    64
+#define PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES		    5
+#define PLDM_RDE_SCHEMA_DICTIONARY_RESP_BYTES		    6
 
 enum pldm_rde_commands {
 	PLDM_NEGOTIATE_REDFISH_PARAMETERS = 0x01,
 	PLDM_NEGOTIATE_MEDIUM_PARAMETERS = 0x02,
+	PLDM_GET_SCHEMA_DICTIONARY = 0x03,
 };
 
 enum pldm_rde_varstring_format {
@@ -83,6 +86,16 @@ struct pldm_rde_varstring {
 	uint8_t string_format;	     // Format of the string
 	uint8_t string_length_bytes; // Length of the string including NULL terminator
 	char *string_data; // Pointer to the string data, should be NULL terminated
+};
+
+/* @brief schemaClass PLDM data type(enum8) Ref section: 5.3.2 */
+enum pldm_rde_schema_type {
+	PLDM_RDE_SCHEMA_MAJOR = 0,
+	PLDM_RDE_SCHEMA_EVENT = 1,
+	PLDM_RDE_SCHEMA_ANNOTATION = 2,
+	PLDM_RDE_SCHEMA_COLLECTION_MEMBER_TYPE = 3,
+	PLDM_RDE_SCHEMA_ERROR = 4,
+	PLDM_RDE_SCHEMA_REGISTRY = 5,
 };
 
 /**
@@ -211,6 +224,70 @@ int decode_negotiate_medium_parameters_resp(const struct pldm_msg *msg,
 					    size_t payload_length,
 					    uint8_t *completion_code,
 					    uint32_t *device_max_transfer_size);
+
+/**
+ * @brief Encode GetSchemaDictionary request.
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] resource_id - The ResourceID of any resource in the Redfish
+ * Resource PDR.A ResourceID of 0xFFFF FFFF may be supplied to retrieve
+ * dictionaries common to all RDE Device resources (such as the event or
+ * annotation dictionary) without referring to an individual resource
+ * @param[in] schema_class - The class of schema being requested.
+ * @param[in] payload_length - Length of request message payload.
+ * @param[out] msg - Request message.
+ * @return pldm_completion_codes.
+ */
+int encode_get_schema_dictionary_req(uint8_t instance_id, uint32_t resource_id,
+				     uint8_t schema_class,
+				     size_t payload_length,
+				     struct pldm_msg *msg);
+
+/**
+ * @brief Decode GetSchemaDictionary request.
+ *
+ * @param[in] msg - Request message.
+ * @param[in] payload_length - Length of request message payload.
+ * @param[out] resource_id - Pointer to a uint32_t variable.
+ * @param[out] requested_schema_class - Pointer to a uint8_t variable.
+ * @return pldm_completion_codes.
+ */
+int decode_get_schema_dictionary_req(const struct pldm_msg *msg,
+				     size_t payload_length,
+				     uint32_t *resource_id,
+				     uint8_t *requested_schema_class);
+
+/**
+ * @brief Encode GetSchemaDictionary response.
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] completion_code - PLDM completion code.
+ * @param[in] dictionary_format - The format of the dictionary.
+ * @param[in] transfer_handle - A data transfer handle that the MC shall
+ * use.
+ * @param[in] payload_length - Length of request message payload.
+ * @param[out] msg - Response message will be written to this.
+ * @return pldm_completion_codes.
+ */
+int encode_get_schema_dictionary_resp(
+	uint8_t instance_id, uint8_t completion_code, uint8_t dictionary_format,
+	uint32_t transfer_handle, size_t payload_length, struct pldm_msg *msg);
+/**
+ * @brief Decode GetSchemaDictionary Response
+ *
+ * @param[in] msg - Response Message
+ * @param[in] payload_length - Length of the payload
+ * @param[out] completion_code - Completion Code
+ * @param[out] dictionary_format - Dictionary Format for the particular
+ * resource id
+ * @param[out] transfer_handle - Transfer Handle to be used to get
+ * dictionary
+ */
+int decode_get_schema_dictionary_resp(const struct pldm_msg *msg,
+				      size_t payload_length,
+				      uint8_t *completion_code,
+				      uint8_t *dictionary_format,
+				      uint32_t *transfer_handle);
 
 #ifdef __cplusplus
 }

--- a/include/libpldm/rde.h
+++ b/include/libpldm/rde.h
@@ -1,0 +1,162 @@
+/* SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later */
+#ifndef RDE_H
+#define RDE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <libpldm/base.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Response lengths are inclusive of completion code */
+#define PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES	    3
+#define PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_RESP_MIN_SIZE 12
+
+enum pldm_rde_commands {
+	PLDM_NEGOTIATE_REDFISH_PARAMETERS = 0x01,
+};
+
+enum pldm_rde_varstring_format {
+	PLDM_RDE_VARSTRING_UNKNOWN = 0,
+	PLDM_RDE_VARSTRING_ASCII = 1,
+	PLDM_RDE_VARSTRING_UTF_8 = 2,
+	PLDM_RDE_VARSTRING_UTF_16 = 3,
+	PLDM_RDE_VARSTRING_UTF_16LE = 4,
+	PLDM_RDE_VARSTRING_UTF_16BE = 5,
+};
+
+/**
+ * @brief MC feature support.
+ *
+ * The flags can be OR'd together to build the feature support for a MC.
+ */
+enum pldm_rde_mc_feature {
+	PLDM_RDE_MC_FEATURE_HEAD_SUPPORTED = 1 << 0,
+	PLDM_RDE_MC_FEATURE_READ_SUPPORTED = 1 << 1,
+	PLDM_RDE_MC_FEATURE_CREATE_SUPPORTED = 1 << 2,
+	PLDM_RDE_MC_FEATURE_DELETE_SUPPORTED = 1 << 3,
+	PLDM_RDE_MC_FEATURE_UPDATE_SUPPORTED = 1 << 4,
+	PLDM_RDE_MC_FEATURE_REPLACE_SUPPORTED = 1 << 5,
+	PLDM_RDE_MC_FEATURE_ACTION_SUPPORTED = 1 << 6,
+	PLDM_RDE_MC_FEATURE_EVENTS_SUPPORTED = 1 << 7,
+	PLDM_RDE_MC_FEATURE_BEJ_1_1_SUPPORTED = 1 << 8,
+	// Reserved bits [15:9]
+};
+
+/**
+ * @brief Device feature support.
+ *
+ * The flags can be OR'd together to build the feature support for an RDE Device.
+ */
+enum pldm_rde_device_feature_support {
+	PLDM_RDE_DEVICE_FEATURE_HEAD_SUPPORTED = 1 << 0,
+	PLDM_RDE_DEVICE_FEATURE_READ_SUPPORTED = 1 << 1,
+	PLDM_RDE_DEVICE_FEATURE_CREATE_SUPPORTED = 1 << 2,
+	PLDM_RDE_DEVICE_FEATURE_DELETE_SUPPORTED = 1 << 3,
+	PLDM_RDE_DEVICE_FEATURE_UPDATE_SUPPORTED = 1 << 4,
+	PLDM_RDE_DEVICE_FEATURE_REPLACE_SUPPORTED = 1 << 5,
+	PLDM_RDE_DEVICE_FEATURE_ACTION_SUPPORTED = 1 << 6,
+	PLDM_RDE_DEVICE_FEATURE_EVENTS_SUPPORTED = 1 << 7,
+	// Reserved bits [15:8]
+};
+
+/**
+ * @brief Device capability flags.
+ *
+ * The flags can be OR'd together to build capabilities of a device.
+ */
+enum device_capabilities_flags {
+	PLDM_RDE_DEVICE_CAP_ATOMIC_RESOURCE_READ = 1 << 0,
+	PLDM_RDE_DEVICE_CAP_EXPAND_SUPPORT = 1 << 1,
+	PLDM_RDE_DEVICE_CAP_BEJ_1_1_SUPPORT = 1 << 2,
+	// Reserved bits [7:3]
+};
+
+/* @brief varstring PLDM data type */
+struct pldm_rde_varstring {
+	uint8_t string_format;	     // Format of the string
+	uint8_t string_length_bytes; // Length of the string including NULL terminator
+	char *string_data; // Pointer to the string data, should be NULL terminated
+};
+
+/**
+ * @brief Encode NegotiateRedfishParameters request.
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] mc_concurrency_support - MC concurrency support.
+ * @param[in] mc_feature_support - MC feature support flags.
+ * @param[out] msg - Request message.
+ * @return pldm_completion_codes.
+ */
+int encode_negotiate_redfish_parameters_req(uint8_t instance_id,
+					    uint8_t mc_concurrency_support,
+					    bitfield16_t *mc_feature_support,
+					    struct pldm_msg *msg);
+
+/**
+ * @brief Decode NegotiateRedfishParameters request.
+ *
+ * @param[in] msg - Request message.
+ * @param[out] mc_concurrency_support - Pointer to a uint8_t variable.
+ * @param[out] mc_feature_support - Pointer to a bitfield16_t variable.
+ * @return pldm_completion_codes.
+ */
+int decode_negotiate_redfish_parameters_req(const struct pldm_msg *msg,
+					    uint8_t *mc_concurrency_support,
+					    bitfield16_t *mc_feature_support);
+
+/**
+ * @brief Encode NegotiateRedfishParameters response
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] completion_code - PLDM completion code.
+ * @param[in] device_concurrency_support - Concurrency support.
+ * @param[in] device_capabilities_flags - Capabilities flags.
+ * @param[in] device_feature_support - Feature support flags.
+ * @param[in] device_configuration_signature - RDE device signature.
+ * @param[in] device_provider_name - Null terminated device provider name.
+ * @param[in] name_format - String format of the device_provider_name.
+* @param[in] payload_length - Length of the payload buffer.
+ * @param[out] msg - Response message will be written to this.
+ * @return pldm_completion_codes.
+ */
+int encode_negotiate_redfish_parameters_resp(
+	uint8_t instance_id, uint8_t completion_code,
+	uint8_t device_concurrency_support,
+	bitfield8_t *device_capabilities_flags,
+	bitfield16_t *device_feature_support,
+	uint32_t device_configuration_signature,
+	const char *device_provider_name,
+	enum pldm_rde_varstring_format name_format, size_t payload_length,
+	struct pldm_msg *msg);
+
+/**
+ * @brief Decode NegotiateRedfishParameters response.
+ *
+ * @param[in] msg - Response message.
+ * @param[out] completion_code - PLDM completion code.
+ * @param[in] payload_length - Length of the payload buffer.
+ * @param[out] device_concurrency_support - Concurrency support.
+ * @param[out] device_capabilities_flags - Capabilities flags.
+ * @param[out] device_feature_support - Feature support flags.
+ * @param[out] device_configuration_signature - RDE device signature.
+ * @param[out] provider_name - Device provider name. provider_name.string_data
+ * will point to the starting location of the provider name in the pldm_msg
+ * buffer.
+ * @return pldm_completion_codes
+ */
+int decode_negotiate_redfish_parameters_resp(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint8_t *completion_code, uint8_t *device_concurrency_support,
+	bitfield8_t *device_capabilities_flags,
+	bitfield16_t *device_feature_support,
+	uint32_t *device_configuration_signature,
+	struct pldm_rde_varstring *provider_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LIBPLDM_RDE_H */

--- a/src/dsp/meson.build
+++ b/src/dsp/meson.build
@@ -7,4 +7,5 @@ libpldm_sources += files(
     'fru.c',
     'pdr.c',
     'platform.c',
+    'rde.c',
 )

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -187,3 +187,141 @@ int decode_negotiate_redfish_parameters_resp(
 
 	return pldm_msgbuf_complete(buf);
 }
+
+LIBPLDM_ABI_STABLE
+int encode_negotiate_medium_parameters_req(uint8_t instance_id,
+					   uint32_t mc_max_transfer_size,
+					   struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.msg_type = PLDM_REQUEST;
+	header.command = PLDM_NEGOTIATE_MEDIUM_PARAMETERS;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES,
+		msg->payload, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, mc_max_transfer_size);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_negotiate_medium_parameters_req(const struct pldm_msg *msg,
+					   uint32_t *mc_max_transfer_size)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || mc_max_transfer_size == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES,
+		msg->payload, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, mc_max_transfer_size);
+	if (*mc_max_transfer_size < PLDM_RDE_MIN_TRANSFER_SIZE_BYTES) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+
+int encode_negotiate_medium_parameters_resp(uint8_t instance_id,
+					    uint8_t completion_code,
+					    uint32_t device_max_transfer_size,
+					    size_t payload_length,
+					    struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (NULL == msg) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_NEGOTIATE_MEDIUM_PARAMETERS;
+
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES,
+		msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	if (completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_insert(buf, device_max_transfer_size);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_negotiate_medium_parameters_resp(const struct pldm_msg *msg,
+					    size_t payload_length,
+					    uint8_t *completion_code,
+					    uint32_t *device_max_transfer_size)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || completion_code == NULL ||
+	    device_max_transfer_size == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES,
+		msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, device_max_transfer_size);
+
+	return pldm_msgbuf_complete(buf);
+}

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -1,0 +1,189 @@
+#include <libpldm/rde.h>
+
+#include "base.h"
+#include "msgbuf.h"
+
+#include <endian.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+LIBPLDM_ABI_STABLE
+int encode_negotiate_redfish_parameters_req(uint8_t instance_id,
+					    uint8_t mc_concurrency_support,
+					    bitfield16_t *mc_feature_support,
+					    struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || mc_concurrency_support == 0 ||
+	    mc_feature_support == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_REQUEST;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_NEGOTIATE_REDFISH_PARAMETERS;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES,
+		msg->payload, PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES);
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, mc_concurrency_support);
+	pldm_msgbuf_insert(buf, mc_feature_support->value);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_negotiate_redfish_parameters_req(const struct pldm_msg *msg,
+					    uint8_t *mc_concurrency_support,
+					    bitfield16_t *mc_feature_support)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || mc_concurrency_support == NULL ||
+	    mc_feature_support == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES,
+		msg->payload, PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES);
+
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, mc_concurrency_support);
+	if (*mc_concurrency_support == 0) {
+		fprintf(stderr,
+			"Concurrency support shall be greater than 0\n");
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	pldm_msgbuf_extract(buf, mc_feature_support->value);
+
+	return pldm_msgbuf_complete(buf);
+}
+LIBPLDM_ABI_STABLE
+int encode_negotiate_redfish_parameters_resp(
+	uint8_t instance_id, uint8_t completion_code,
+	uint8_t device_concurrency_support,
+	bitfield8_t *device_capabilities_flags,
+	bitfield16_t *device_feature_support,
+	uint32_t device_configuration_signature,
+	const char *device_provider_name,
+	enum pldm_rde_varstring_format name_format, size_t payload_length,
+	struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || device_capabilities_flags == NULL ||
+	    device_feature_support == NULL || device_provider_name == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	if (completion_code != PLDM_SUCCESS) {
+		return encode_cc_only_resp(instance_id, PLDM_RDE,
+					   PLDM_NEGOTIATE_REDFISH_PARAMETERS,
+					   completion_code, msg);
+	}
+
+	// Length should include NULL terminator.
+	size_t str_len = strlen(device_provider_name) + 1;
+	if (str_len > 255) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_NEGOTIATE_REDFISH_PARAMETERS;
+
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_RESP_MIN_SIZE,
+		msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	pldm_msgbuf_insert(buf, device_concurrency_support);
+	pldm_msgbuf_insert(buf, device_capabilities_flags->byte);
+	pldm_msgbuf_insert(buf, device_feature_support->value);
+	pldm_msgbuf_insert(buf, device_configuration_signature);
+	pldm_msgbuf_insert_uint8(buf, name_format);
+	pldm_msgbuf_insert(buf, (uint8_t)str_len);
+	rc = pldm_msgbuf_insert_array(
+		buf, str_len, (const uint8_t *)device_provider_name, str_len);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_negotiate_redfish_parameters_resp(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint8_t *completion_code, uint8_t *device_concurrency_support,
+	bitfield8_t *device_capabilities_flags,
+	bitfield16_t *device_feature_support,
+	uint32_t *device_configuration_signature,
+	struct pldm_rde_varstring *provider_name)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || completion_code == NULL ||
+	    device_concurrency_support == NULL ||
+	    device_capabilities_flags == NULL ||
+	    device_feature_support == NULL ||
+	    device_configuration_signature == NULL || provider_name == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_RESP_MIN_SIZE,
+		msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, device_concurrency_support);
+	pldm_msgbuf_extract_p(buf, &device_capabilities_flags->byte);
+	pldm_msgbuf_extract_p(buf, &device_feature_support->value);
+	pldm_msgbuf_extract_p(buf, device_configuration_signature);
+	pldm_msgbuf_extract_p(buf, &provider_name->string_format);
+	pldm_msgbuf_extract_p(buf, &provider_name->string_length_bytes);
+
+	pldm_msgbuf_span_required(buf, provider_name->string_length_bytes,
+				  (void **)&provider_name->string_data);
+
+	return pldm_msgbuf_complete(buf);
+}

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -688,3 +688,149 @@ int decode_get_schema_uri_resp(const struct pldm_msg *msg,
 
 	return pldm_msgbuf_complete(buf);
 }
+
+LIBPLDM_ABI_STABLE
+int encode_get_resource_etag_req(uint8_t instance_id, uint32_t resource_id,
+				 struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_REQUEST;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_GET_RESOURCE_ETAG;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_GET_RESOURCE_ETAG_REQ_BYTES,
+				    msg->payload,
+				    PLDM_RDE_GET_RESOURCE_ETAG_REQ_BYTES);
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, resource_id);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_resource_etag_req(const struct pldm_msg *msg,
+				 uint32_t *resource_id)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || resource_id == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_GET_RESOURCE_ETAG_REQ_BYTES,
+				    msg->payload,
+				    PLDM_RDE_GET_RESOURCE_ETAG_REQ_BYTES);
+
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, resource_id);
+
+	return pldm_msgbuf_complete(buf);
+}
+LIBPLDM_ABI_STABLE
+int encode_get_resource_etag_resp(uint8_t instance_id, uint8_t completion_code,
+				  const char *etag_string_data,
+				  struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || etag_string_data == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	if (completion_code != PLDM_SUCCESS) {
+		return encode_cc_only_resp(instance_id, PLDM_RDE,
+					   PLDM_GET_RESOURCE_ETAG,
+					   completion_code, msg);
+	}
+
+	// Length should include NULL terminator.
+	size_t str_len = strlen(etag_string_data) + 1;
+	if (str_len > 255) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_GET_RESOURCE_ETAG;
+
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf,
+				    PLDM_RDE_GET_RESOURCE_ETAG_RESP_FIXED_BYTES,
+				    msg->payload,
+				    PLDM_GET_RESOURCE_ETAG + str_len);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	pldm_msgbuf_insert_uint8(buf, PLDM_RDE_VARSTRING_UTF_8);
+	pldm_msgbuf_insert(buf, (uint8_t)str_len);
+	rc = pldm_msgbuf_insert_array(
+		buf, str_len, (const uint8_t *)etag_string_data, str_len);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_resource_etag_resp(const struct pldm_msg *msg,
+				  size_t payload_length,
+				  uint8_t *completion_code,
+				  struct pldm_rde_varstring *etag)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || completion_code == NULL || etag == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf,
+				    PLDM_RDE_GET_RESOURCE_ETAG_RESP_FIXED_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, &etag->string_format);
+	pldm_msgbuf_extract_p(buf, &etag->string_length_bytes);
+
+	pldm_msgbuf_span_required(buf, etag->string_length_bytes,
+				  (void **)&etag->string_data);
+
+	return pldm_msgbuf_complete(buf);
+}

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -469,3 +469,222 @@ int decode_get_schema_dictionary_resp(const struct pldm_msg *msg,
 	}
 	return pldm_msgbuf_complete(buf);
 }
+
+LIBPLDM_ABI_STABLE
+int encode_get_schema_uri_req(uint8_t instance_id, uint32_t resource_id,
+			      uint8_t req_schema_class,
+			      uint8_t oem_extension_number,
+			      struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.msg_type = PLDM_REQUEST;
+	header.command = PLDM_GET_SCHEMA_URI;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_URI_REQ_BYTES,
+				    msg->payload,
+				    PLDM_RDE_SCHEMA_URI_REQ_BYTES);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, resource_id);
+	pldm_msgbuf_insert(buf, req_schema_class);
+	pldm_msgbuf_insert(buf, oem_extension_number);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_schema_uri_req(const struct pldm_msg *msg, uint32_t *resource_id,
+			      uint8_t *req_schema_class,
+			      uint8_t *oem_extension_number)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || resource_id == NULL || req_schema_class == NULL ||
+	    oem_extension_number == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_URI_REQ_BYTES,
+				    msg->payload,
+				    PLDM_RDE_SCHEMA_URI_REQ_BYTES);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, resource_id);
+	pldm_msgbuf_extract_p(buf, req_schema_class);
+	pldm_msgbuf_extract_p(buf, oem_extension_number);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int encode_get_schema_uri_resp(uint8_t instance_id, uint8_t completion_code,
+			       uint8_t string_fragment_count,
+			       const struct pldm_rde_varstring *schema_uri,
+			       struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (!msg || !schema_uri || string_fragment_count == 0) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	// Set up PLDM header
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_GET_SCHEMA_URI;
+
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	size_t payload_length = PLDM_RDE_SCHEMA_URI_RESP_FIXED_BYTES;
+	for (int i = 0; i < string_fragment_count; ++i) {
+		payload_length += PLDM_RDE_VARSTRING_HEADER_SIZE +
+				  schema_uri[i].string_length_bytes;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, payload_length, msg->payload,
+				    payload_length);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	// Insert fixed fields
+	pldm_msgbuf_insert(buf, completion_code);
+	pldm_msgbuf_insert(buf, string_fragment_count);
+
+	// Insert each varstring
+	for (uint8_t i = 0; i < string_fragment_count; ++i) {
+		const struct pldm_rde_varstring *entry = &schema_uri[i];
+
+		if (!entry->string_data || entry->string_length_bytes == 0) {
+			fprintf(stderr,
+				"Invalid entry at index %d: data=%p, length=%d\n",
+				i, entry->string_data,
+				entry->string_length_bytes);
+			return PLDM_ERROR_INVALID_DATA;
+		}
+
+		size_t str_len = entry->string_length_bytes;
+
+		pldm_msgbuf_insert_uint8(buf, entry->string_format);
+		pldm_msgbuf_insert_uint8(buf, str_len);
+
+		rc = pldm_msgbuf_insert_array_char(
+			buf, str_len, (const char *)entry->string_data,
+			str_len);
+		if (rc != PLDM_SUCCESS) {
+			fprintf(stderr,
+				"Insert failed at index (%d) remaining:%jd\n",
+				i, buf->remaining);
+			return rc;
+		}
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_schema_uri_resp(const struct pldm_msg *msg,
+			       uint8_t *completion_code,
+			       uint8_t *string_fragment_count,
+			       struct pldm_rde_varstring *schema_uri_array,
+			       size_t payload_length, size_t *actual_uri_len)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (!msg || !completion_code || !string_fragment_count) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_URI_RESP_FIXED_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	rc = pldm_msgbuf_extract_p(buf, string_fragment_count);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	if (*string_fragment_count == 0) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	*actual_uri_len = 0;
+
+	for (uint8_t i = 0; i < *string_fragment_count; ++i) {
+		uint8_t format = 0;
+		uint8_t length = 0;
+
+		rc = pldm_msgbuf_extract(buf, format);
+		if (rc != PLDM_SUCCESS) {
+			return rc;
+		}
+
+		rc = pldm_msgbuf_extract(buf, length);
+
+		if (rc != PLDM_SUCCESS || length <= 1) {
+			return PLDM_ERROR_INVALID_LENGTH;
+		}
+
+		*actual_uri_len += length;
+		if (*actual_uri_len >
+		    (payload_length - PLDM_RDE_SCHEMA_URI_RESP_FIXED_BYTES)) {
+			return PLDM_ERROR_INVALID_LENGTH;
+		}
+
+		schema_uri_array[i].string_format = format;
+		schema_uri_array[i].string_length_bytes = length;
+
+		void *span_ptr = NULL;
+
+		rc = pldm_msgbuf_span_required(buf, length - 1, &span_ptr);
+		if (rc != PLDM_SUCCESS) {
+			return rc;
+		}
+		schema_uri_array[i].string_data = (char *)span_ptr;
+
+		// Extract null terminator
+		uint8_t dummy;
+		rc = pldm_msgbuf_extract_p(buf, &dummy);
+		if (rc != PLDM_SUCCESS) {
+			return rc;
+		}
+		// Ensure null-termination
+		schema_uri_array[i].string_data[length - 1] = '\0';
+	}
+
+	return pldm_msgbuf_complete(buf);
+}

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -325,3 +325,147 @@ int decode_negotiate_medium_parameters_resp(const struct pldm_msg *msg,
 
 	return pldm_msgbuf_complete(buf);
 }
+
+LIBPLDM_ABI_STABLE
+int encode_get_schema_dictionary_req(uint8_t instance_id, uint32_t resource_id,
+				     uint8_t schema_class,
+				     size_t payload_length,
+				     struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.msg_type = PLDM_REQUEST;
+	header.command = PLDM_GET_SCHEMA_DICTIONARY;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, resource_id);
+	pldm_msgbuf_insert(buf, schema_class);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_schema_dictionary_req(const struct pldm_msg *msg,
+				     size_t payload_length,
+				     uint32_t *resource_id,
+				     uint8_t *requested_schema_class)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || resource_id == NULL ||
+	    requested_schema_class == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	if (payload_length != PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES) {
+		return PLDM_ERROR_INVALID_LENGTH;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, resource_id);
+	pldm_msgbuf_extract_p(buf, requested_schema_class);
+	if (*requested_schema_class > PLDM_RDE_SCHEMA_REGISTRY) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int encode_get_schema_dictionary_resp(
+	uint8_t instance_id, uint8_t completion_code, uint8_t dictionary_format,
+	uint32_t transfer_handle, size_t payload_length, struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (NULL == msg) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_GET_SCHEMA_DICTIONARY;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_DICTIONARY_RESP_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	if (completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_insert(buf, dictionary_format);
+	pldm_msgbuf_insert(buf, transfer_handle);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_schema_dictionary_resp(const struct pldm_msg *msg,
+				      size_t payload_length,
+				      uint8_t *completion_code,
+				      uint8_t *dictionary_format,
+				      uint32_t *transfer_handle)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if ((msg == NULL) || (dictionary_format == NULL) ||
+	    (completion_code == NULL) || (transfer_handle == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_RDE_SCHEMA_DICTIONARY_RESP_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, dictionary_format);
+	pldm_msgbuf_extract_p(buf, transfer_handle);
+
+	if (*dictionary_format > PLDM_RDE_SCHEMA_REGISTRY) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+	return pldm_msgbuf_complete(buf);
+}

--- a/tests/dsp/meson.build
+++ b/tests/dsp/meson.build
@@ -7,6 +7,7 @@ tests += [
     'dsp/fru',
     'dsp/pdr',
     'dsp/platform',
+    'dsp/rde',
 ]
 
 test(

--- a/tests/dsp/rde.cpp
+++ b/tests/dsp/rde.cpp
@@ -1,0 +1,111 @@
+#include <libpldm/pldm_types.h>
+#include <libpldm/rde.h>
+
+#include <array>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+static const uint8_t FIXED_INSTANCE_ID = 15;
+
+/* data is a pointer to pldm message response header */
+
+static void checkHeader(const pldm_msg* msg, uint8_t command,
+                        MessageType request)
+{
+    if (msg == nullptr)
+    {
+        std::cout << "Message is NULL\n";
+        return;
+    }
+
+    EXPECT_EQ(msg->hdr.request, request);
+    EXPECT_EQ(msg->hdr.type, PLDM_RDE);
+    EXPECT_EQ(msg->hdr.command, command);
+    EXPECT_EQ(msg->hdr.instance_id, FIXED_INSTANCE_ID);
+}
+
+TEST(NegotiateRedfishParametersTest, EncodeDecodeRequestSuccess)
+{
+    uint8_t mcConcurrencySupport = 13;
+    bitfield16_t mcFeatureSupport = {.value = 0x7389};
+
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) +
+                            PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_REQ_BYTES>
+        requestMsg{};
+    pldm_msg* request = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_negotiate_redfish_parameters_req(
+                  FIXED_INSTANCE_ID, mcConcurrencySupport, &mcFeatureSupport,
+                  request),
+              PLDM_SUCCESS);
+
+    checkHeader(request, PLDM_NEGOTIATE_REDFISH_PARAMETERS, PLDM_REQUEST);
+
+    uint8_t decodedMcConcurrencySupport;
+    bitfield16_t decodedMcFeatureSupport;
+
+    EXPECT_EQ(
+        decode_negotiate_redfish_parameters_req(
+            request, &decodedMcConcurrencySupport, &decodedMcFeatureSupport),
+        PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedMcConcurrencySupport, mcConcurrencySupport);
+    EXPECT_EQ(decodedMcFeatureSupport.value, mcFeatureSupport.value);
+}
+
+TEST(NegotiateRedfishParametersTest, EncodeDecodeResponseSuccess)
+{
+    uint8_t completionCode = 0;
+
+    uint8_t deviceConcurrencySupport = 1;
+    bitfield8_t deviceCapabilitiesFlags = {.byte = 0x3F};
+    bitfield16_t deviceFeatureSupport = {.value = 0x7389};
+    uint32_t deviceConfigurationSignature = 0xDEADBEEF;
+    constexpr const char* device = "Test Device";
+
+    constexpr size_t payloadLength =
+        PLDM_RDE_NEGOTIATE_REDFISH_PARAMETERS_RESP_MIN_SIZE + 11;
+
+    // Already has the space for the null character in sizeof(struct
+    // pldm_rde_negotiate_redfish_parameters_resp).
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) + payloadLength>
+        responseMsg{};
+    pldm_msg* response = (pldm_msg*)responseMsg.data();
+
+    EXPECT_EQ(encode_negotiate_redfish_parameters_resp(
+                  FIXED_INSTANCE_ID, completionCode, deviceConcurrencySupport,
+                  &deviceCapabilitiesFlags, &deviceFeatureSupport,
+                  deviceConfigurationSignature, device,
+                  PLDM_RDE_VARSTRING_ASCII, payloadLength, response),
+              PLDM_SUCCESS);
+
+    checkHeader(response, PLDM_NEGOTIATE_REDFISH_PARAMETERS, PLDM_RESPONSE);
+
+    // verify payload.
+    uint8_t decodedCompletionCode;
+    uint8_t decodedDeviceConcurrencySupport;
+    bitfield8_t decodedDeviceCapabilitiesFlags;
+    bitfield16_t decodedDeviceFeatureSupport;
+    uint32_t decodedDeviceConfigurationSignature;
+    struct pldm_rde_varstring decodedProviderName;
+
+    EXPECT_EQ(decode_negotiate_redfish_parameters_resp(
+                  response, payloadLength, &decodedCompletionCode,
+                  &decodedDeviceConcurrencySupport,
+                  &decodedDeviceCapabilitiesFlags, &decodedDeviceFeatureSupport,
+                  &decodedDeviceConfigurationSignature, &decodedProviderName),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedCompletionCode, completionCode);
+    EXPECT_EQ(decodedDeviceConcurrencySupport, deviceConcurrencySupport);
+    EXPECT_EQ(decodedDeviceCapabilitiesFlags.byte,
+              deviceCapabilitiesFlags.byte);
+    EXPECT_EQ(decodedDeviceFeatureSupport.value, deviceFeatureSupport.value);
+    EXPECT_EQ(decodedDeviceConfigurationSignature,
+              deviceConfigurationSignature);
+    EXPECT_EQ(decodedProviderName.string_format, PLDM_RDE_VARSTRING_ASCII);
+    EXPECT_EQ(decodedProviderName.string_length_bytes, strlen(device) + 1);
+    EXPECT_EQ(strncmp(device, decodedProviderName.string_data, strlen(device)),
+              0);
+}

--- a/tests/dsp/rde.cpp
+++ b/tests/dsp/rde.cpp
@@ -162,3 +162,66 @@ TEST(NegotiateMediumParametersTest, EncodeDecodeResponseSuccess)
     EXPECT_EQ(decodedCompletionCode, completionCode);
     EXPECT_EQ(decodedDeviceMaximumTransferSize, deviceMaximumTransferSize);
 }
+
+TEST(GetSchemaDictionaryTest, EncodeDecodeRequestSuccess)
+{
+    uint32_t resorceID = 0xDEADBEEF;
+    uint8_t requestedSchemaClass = PLDM_RDE_SCHEMA_MAJOR;
+
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) +
+                            PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES>
+        requestMsg{};
+    pldm_msg* request = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_get_schema_dictionary_req(
+                  FIXED_INSTANCE_ID, resorceID, requestedSchemaClass,
+                  PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES, request),
+              PLDM_SUCCESS);
+
+    checkHeader(request, PLDM_GET_SCHEMA_DICTIONARY, PLDM_REQUEST);
+
+    uint32_t decodeResorceID;
+    uint8_t decodeRequestedSchemaClass;
+
+    EXPECT_EQ(decode_get_schema_dictionary_req(
+                  request, PLDM_RDE_SCHEMA_DICTIONARY_REQ_BYTES,
+                  &decodeResorceID, &decodeRequestedSchemaClass),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodeResorceID, resorceID);
+    EXPECT_EQ(requestedSchemaClass, requestedSchemaClass);
+}
+
+TEST(GetSchemaDictionaryTest, EncodeDecodeResponseSuccess)
+{
+    uint8_t completionCode = PLDM_SUCCESS;
+    uint8_t dictionaryFormat = PLDM_RDE_SCHEMA_MAJOR;
+    uint32_t transferHandle = 0xDEADBEEF;
+
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) +
+                            PLDM_RDE_SCHEMA_DICTIONARY_RESP_BYTES>
+        responseMsg{};
+    pldm_msg* response = (pldm_msg*)responseMsg.data();
+
+    EXPECT_EQ(encode_get_schema_dictionary_resp(
+                  FIXED_INSTANCE_ID, completionCode, dictionaryFormat,
+                  transferHandle, PLDM_RDE_SCHEMA_DICTIONARY_RESP_BYTES,
+                  response),
+              PLDM_SUCCESS);
+
+    checkHeader(response, PLDM_GET_SCHEMA_DICTIONARY, PLDM_RESPONSE);
+
+    uint8_t decodeCompletionCode;
+    uint8_t decodeDictionaryFormat;
+    uint32_t decodeTransferHandle;
+
+    EXPECT_EQ(decode_get_schema_dictionary_resp(
+                  response, PLDM_RDE_SCHEMA_DICTIONARY_RESP_BYTES,
+                  &decodeCompletionCode, &decodeDictionaryFormat,
+                  &decodeTransferHandle),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodeCompletionCode, completionCode);
+    EXPECT_EQ(decodeDictionaryFormat, dictionaryFormat);
+    EXPECT_EQ(decodeTransferHandle, transferHandle);
+}

--- a/tests/dsp/rde.cpp
+++ b/tests/dsp/rde.cpp
@@ -109,3 +109,56 @@ TEST(NegotiateRedfishParametersTest, EncodeDecodeResponseSuccess)
     EXPECT_EQ(strncmp(device, decodedProviderName.string_data, strlen(device)),
               0);
 }
+
+TEST(NegotiateMediumParametersTest, EncodeDecodeRequestSuccess)
+{
+    uint32_t mcMaximumTransferSize = 0xDEADBEEF;
+
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) +
+                            PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_REQ_BYTES>
+        requestMsg{};
+    pldm_msg* request = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_negotiate_medium_parameters_req(
+                  FIXED_INSTANCE_ID, mcMaximumTransferSize, request),
+              PLDM_SUCCESS);
+
+    checkHeader(request, PLDM_NEGOTIATE_MEDIUM_PARAMETERS, PLDM_REQUEST);
+
+    uint32_t decodedMcMaximumTransferSize;
+
+    EXPECT_EQ(decode_negotiate_medium_parameters_req(
+                  request, &decodedMcMaximumTransferSize),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedMcMaximumTransferSize, mcMaximumTransferSize);
+}
+
+TEST(NegotiateMediumParametersTest, EncodeDecodeResponseSuccess)
+{
+    uint8_t completionCode = PLDM_SUCCESS;
+    uint32_t deviceMaximumTransferSize = 0xDEADBEEF;
+
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) +
+                            PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES>
+        responseMsg{};
+    pldm_msg* response = (pldm_msg*)responseMsg.data();
+
+    EXPECT_EQ(encode_negotiate_medium_parameters_resp(
+                  FIXED_INSTANCE_ID, completionCode, deviceMaximumTransferSize,
+                  PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES, response),
+              PLDM_SUCCESS);
+
+    checkHeader(response, PLDM_NEGOTIATE_MEDIUM_PARAMETERS, PLDM_RESPONSE);
+
+    uint8_t decodedCompletionCode;
+    uint32_t decodedDeviceMaximumTransferSize;
+
+    EXPECT_EQ(decode_negotiate_medium_parameters_resp(
+                  response, PLDM_RDE_NEGOTIATE_MEDIUM_PARAMETERS_RESP_BYTES,
+                  &decodedCompletionCode, &decodedDeviceMaximumTransferSize),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedCompletionCode, completionCode);
+    EXPECT_EQ(decodedDeviceMaximumTransferSize, deviceMaximumTransferSize);
+}


### PR DESCRIPTION
Added an API for encoding/decoding functions for

- NegotiateRedfishParameters requests and responses as per DSP0218 v1.2 section 11.1
- NegotiateMediumParameters requests and responses as per DSP0218 v1.2 section 11.2
- GetSchemaDictionary requests and responses as per DSP0218 v1.2 section 11.3
- GetSchemaURI requests and responses as per DSP0218 v1.2 section 11.4
- GetResourceETag command (0x05) format equests and responses as per DSP0218 v1.2 section 11.5