### PR TITLE
RDE: Add RDEMultipartSend cmd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Change categories:
 - rde: Add GetSchemaDictionary support
 - rde: Add GetSchemaURI support
 - rde: Add GetResourceETag support
+- rde: Add RDEMultipartSend support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/include/libpldm/pldm_types.h
+++ b/include/libpldm/pldm_types.h
@@ -18,6 +18,9 @@ typedef union {
 	} __attribute__((packed)) bits;
 } bitfield8_t;
 
+// Define rdeOpID as a 16-bit unsigned integer
+typedef uint16_t rde_op_id;
+
 /** @struct pldm_version
  *
  *


### PR DESCRIPTION
Add encode and decode APIs for RDEMultipartSend command as per DSP0218
v1.2 section 13.1.

Tests:
Unit tested passed.

Signed-off-by: Raja Sekhar Reddy Gade <rajagade@amd.com>