### PR TITLE
RDE: Add RDEOperationInit cmd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Change categories:
 - rde: Add GetResourceETag support
 - rde: Add RDEMultipartSend support
 - rde: Add RDEMultipartReceive support
+- rde: Add RDEOperationInit support
 - rde: Add RDEOperationComplete support
 - rde: Add RDEOperationStatus support
 - rde: Add RDEOperationEnumerate support

--- a/include/libpldm/rde.h
+++ b/include/libpldm/rde.h
@@ -28,6 +28,8 @@ extern "C" {
 #define PLDM_RDE_MULTIPART_SEND_RESP_BYTES		    2
 #define PLDM_RDE_MULTIPART_RECEIVE_REQ_BYTES		    7
 #define PLDM_RDE_MULTIPART_RECEIVE_RESP_FIXED_BYTES	    10
+#define PLDM_RDE_OPERATION_INIT_REQ_FIXED_BYTES		    17
+#define PLDM_RDE_OPERATION_INIT_RESP_FIXED_BYTES	    17
 #define PLDM_RDE_OPERATION_COMPLETE_REQ_BYTES		    6
 #define PLDM_RDE_OPERATION_COMPLETE_RESP_BYTES		    1
 #define PLDM_RDE_OPERATION_STATUS_REQ_BYTES		    6
@@ -40,6 +42,7 @@ enum pldm_rde_commands {
 	PLDM_GET_SCHEMA_DICTIONARY = 0x03,
 	PLDM_GET_SCHEMA_URI = 0x04,
 	PLDM_GET_RESOURCE_ETAG = 0x05,
+	PLDM_RDE_OPERATION_INIT = 0x10,
 	PLDM_RDE_OPERATION_COMPLETE = 0x13,
 	PLDM_RDE_OPERATION_STATUS = 0x14,
 	PLDM_RDE_OPERATION_ENUMERATE = 0x16,
@@ -661,6 +664,116 @@ int decode_rde_multipart_receive_resp(
 	uint8_t *completion_code, uint8_t *transfer_flag,
 	uint32_t *data_transfer_handle, uint32_t *data_length_bytes,
 	uint8_t *data, uint32_t *data_integrity_checksum);
+
+/**
+ * @brief Encode RDEOperationInit request.
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] resource_id - The ResourceID.
+ * @param[in] operation_id - Identification number for this operation.
+ * @param[in] operation_type - The type of Redfish Operation being
+ * performed.
+ * @param[in] operation_flags - Flags associated with this Operation.
+ * @param[in] send_data_transfer_handle - Handle to be used with the first
+ * RDEMultipartSend command.
+ * @param[in] operation_locator_length - Length of the OperationLocator for
+ * this Operation.
+ * @param[in] request_payload_length - Length of the request payload in this
+ * message.
+ * @param[in] operation_locator - BEJ locator indicating where the new
+ * Operation is to take place within the resource.
+ * @param[in] request_payload - The request payload.
+ * @param[out] msg - Request will be written to this.
+ * @return pldm_completion_codes.
+ */
+int encode_rde_operation_init_req(
+	uint8_t instance_id, uint32_t resource_id, rde_op_id operation_id,
+	uint8_t operation_type, bitfield8_t *operation_flags,
+	uint32_t send_data_transfer_handle, uint8_t operation_locator_length,
+	uint32_t request_payload_length, const uint8_t *operation_locator,
+	const uint8_t *request_payload, struct pldm_msg *msg);
+
+/**
+ * @brief Decode RDEOperationInit request.
+ *
+ * @param[in] msg - Request message.
+ * @param[in] payload_length - Length of request message payload.
+ * @param[out] resource_id - The ResourceID.
+ * @param[out] operation_id - Identification number for this operation.
+ * @param[out] operation_type - The type of Redfish Operation being
+ * performed.
+ * @param[out] operation_flags  - Flags associated with this Operation.
+ * @param[out] send_data_transfer_handle - Handle to be used with the first
+ * RDEMultipartSend command.
+ * @param[out] operation_locator_length - Length of the OperationLocator for
+ * this Operation.
+ * @param[out] request_payload_length - Length of the request payload in
+ * this message.
+ * @param[out] operation_locator - BEJ locator indicating where the new
+ * Operation is to take place within the resource.
+ * @param[out] request_payload - The request payload.
+* @return pldm_completion_codes.
+ */
+int decode_rde_operation_init_req(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint32_t *resource_id, rde_op_id *operation_id, uint8_t *operation_type,
+	bitfield8_t *operation_flags, uint32_t *send_data_transfer_handle,
+	uint8_t *operation_locator_length, uint32_t *request_payload_length,
+	uint8_t *operation_locator, uint8_t *request_payload);
+/**
+ * @brief Encode RDEOperationInit response.
+ *
+ * @param[in] instance_id - Message's instance id.
+ * @param[in] completion_code - PLDM completion code.
+ * @param[in] operation_status - Status of the operation.
+ * @param[in] completion_percentage - Percentage complete.
+ * @param[in] completion_time_seconds - An estimate of the number of seconds
+ * remaining before the Operation is completed.
+ * @param[in] operation_execution_flags - Explains the result of operation.
+ * @param[in] result_transfer_handle - A data transfer handle that the MC
+ * may use to retrieve a larger response payload.
+ * @param[in] permission_flags - Indicates the access level granted to the
+ * resource targeted by the Operation.
+ * @param[in] response_payload_length - Length of the response payload.
+ * @param[in] etag - ETag.
+ * @param[in] response_payload - The response payload if the payload fits.
+ * @param[out] msg - Response message will be written to this.
+ * @return pldm_completion_codes.
+ */
+int encode_rde_operation_init_resp(
+	uint8_t instance_id, uint8_t completion_code, uint8_t operation_status,
+	uint8_t completion_percentage, uint32_t completion_time_seconds,
+	bitfield8_t *operation_execution_flags, uint32_t result_transfer_handle,
+	bitfield8_t *permission_flags, uint32_t response_payload_length,
+	const char *etag, const uint8_t *response_payload,
+	struct pldm_msg *msg);
+
+/**
+ * @brief Decode RDEOperationInit Resp
+ *
+ * @param[in] msg - Request message.
+ * @param[in] payload_len - Request message lenght.
+ * @param[out] completion_code - Pointer to completion Code
+ * @param[in] completion_percentage - Pointer to percentage complete.
+ * @param[in] operation_status - Pointer to status of the operation.
+ * @param[in] completion_percentage - Pointer to percentage complete.
+ * @param[in] completion_time_seconds - Pointer to completion_time_seconds
+ * @param[in] operation_execution_flags - Pointer to operation_execution_flags.
+ * @param[in] result_transfer_handle - Pointer to result_transfer_handle
+ * @param[in] permission_flags - Pointer to permission_flags
+ * @param[in] response_payload_length - Pointer to response_payload_length.
+ * @param[in] etag - Pointer to ETag.
+ * @param[in] response_payload - The response payload if the payload fits.
+  * @return pldm_completion_codes.
+ */
+int decode_rde_operation_init_resp(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint8_t *completion_code, uint8_t *operation_status,
+	uint8_t *completion_percentage, uint32_t *completion_time_seconds,
+	bitfield8_t *operation_execution_flags,
+	uint32_t *result_transfer_handle, bitfield8_t *permission_flags,
+	uint32_t *response_payload_length, struct pldm_rde_varstring *etag,
+	uint8_t *response_payload);
 
 /**
  * @brief Encode RDEOperationComplete request.

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -1225,6 +1225,281 @@ int decode_rde_multipart_receive_resp(
 }
 
 LIBPLDM_ABI_STABLE
+int encode_rde_operation_init_req(
+	uint8_t instance_id, uint32_t resource_id, rde_op_id operation_id,
+	uint8_t operation_type, bitfield8_t *operation_flags,
+	uint32_t send_data_transfer_handle, uint8_t operation_locator_length,
+	uint32_t request_payload_length, const uint8_t *operation_locator,
+	const uint8_t *request_payload, struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if ((msg == NULL) || (operation_flags == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+	if ((operation_locator_length > 0) && (operation_locator == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+	if ((request_payload_length > 0) && (request_payload == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.msg_type = PLDM_REQUEST;
+	header.command = PLDM_RDE_OPERATION_INIT;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(
+		buf, PLDM_RDE_OPERATION_INIT_REQ_FIXED_BYTES, msg->payload,
+		PLDM_RDE_OPERATION_INIT_REQ_FIXED_BYTES +
+			operation_locator_length + request_payload_length);
+
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, resource_id);
+	pldm_msgbuf_insert(buf, operation_id);
+	pldm_msgbuf_insert(buf, operation_type);
+	pldm_msgbuf_insert(buf, operation_flags->byte);
+
+	if ((operation_flags->bits.bit2) && (send_data_transfer_handle == 0)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	pldm_msgbuf_insert(buf, send_data_transfer_handle);
+	pldm_msgbuf_insert(buf, operation_locator_length);
+	pldm_msgbuf_insert(buf, request_payload_length);
+
+	if (operation_flags->bits.bit0) {
+		rc = pldm_msgbuf_insert_array(
+			buf, operation_locator_length,
+			(const uint8_t *)operation_locator,
+			operation_locator_length);
+		if (rc != PLDM_SUCCESS) {
+			return rc;
+		}
+	}
+
+	if (operation_flags->bits.bit1) {
+		rc = pldm_msgbuf_insert_array(buf, request_payload_length,
+					      (const uint8_t *)request_payload,
+					      request_payload_length);
+		if (rc != PLDM_SUCCESS) {
+			return rc;
+		}
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_rde_operation_init_req(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint32_t *resource_id, rde_op_id *operation_id, uint8_t *operation_type,
+	bitfield8_t *operation_flags, uint32_t *send_data_transfer_handle,
+	uint8_t *operation_locator_length, uint32_t *request_payload_length,
+	uint8_t *operation_locator, uint8_t *request_payload)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if ((msg == NULL) || (resource_id == NULL) || (operation_id == NULL) ||
+	    (operation_type == NULL) || (operation_flags == NULL) ||
+	    (send_data_transfer_handle == NULL) ||
+	    (operation_locator_length == NULL) ||
+	    (request_payload_length == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+	if (payload_length < PLDM_RDE_OPERATION_INIT_REQ_FIXED_BYTES) {
+		return PLDM_ERROR_INVALID_LENGTH;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf,
+				    PLDM_RDE_MULTIPART_SEND_REQ_FIXED_BYTES,
+				    msg->payload, payload_length);
+
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, resource_id);
+	pldm_msgbuf_extract_p(buf, operation_id);
+	pldm_msgbuf_extract_p(buf, operation_type);
+	pldm_msgbuf_extract(buf, operation_flags->byte);
+	pldm_msgbuf_extract_p(buf, send_data_transfer_handle);
+	pldm_msgbuf_extract_p(buf, operation_locator_length);
+	pldm_msgbuf_extract_p(buf, request_payload_length);
+
+	if (operation_flags->bits.bit0) {
+		rc = pldm_msgbuf_extract_array(buf, *operation_locator_length,
+					       operation_locator,
+					       *operation_locator_length);
+		if (rc) {
+			return pldm_msgbuf_discard(buf, rc);
+		}
+	} else {
+		operation_locator = NULL;
+	}
+
+	if (operation_flags->bits.bit1) {
+		rc = pldm_msgbuf_extract_array(buf, *request_payload_length,
+					       request_payload,
+					       *request_payload_length);
+		if (rc) {
+			return pldm_msgbuf_discard(buf, rc);
+		}
+	} else {
+		request_payload = NULL;
+	}
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int encode_rde_operation_init_resp(
+	uint8_t instance_id, uint8_t completion_code, uint8_t operation_status,
+	uint8_t completion_percentage, uint32_t completion_time_seconds,
+	bitfield8_t *operation_execution_flags, uint32_t result_transfer_handle,
+	bitfield8_t *permission_flags, uint32_t response_payload_length,
+	const char *etag, const uint8_t *response_payload, struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if ((msg == NULL) || (operation_execution_flags == NULL) ||
+	    (permission_flags == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+	if ((response_payload_length > 0) && (response_payload == NULL)) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	if (completion_code != PLDM_SUCCESS) {
+		return encode_cc_only_resp(instance_id, PLDM_RDE,
+					   PLDM_RDE_OPERATION_INIT,
+					   completion_code, msg);
+	}
+	// Length should include NULL terminator.
+	size_t str_len = strlen(etag) + 1;
+	if (str_len > 255) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header;
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_RDE_OPERATION_INIT;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf,
+				    PLDM_RDE_OPERATION_INIT_RESP_FIXED_BYTES,
+				    msg->payload,
+				    PLDM_RDE_OPERATION_INIT_RESP_FIXED_BYTES +
+					    PLDM_RDE_VARSTRING_HEADER_SIZE +
+					    str_len + response_payload_length);
+	if (rc) {
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	pldm_msgbuf_insert(buf, operation_status);
+	pldm_msgbuf_insert(buf, completion_percentage);
+	pldm_msgbuf_insert(buf, completion_time_seconds);
+	pldm_msgbuf_insert(buf, operation_execution_flags->byte);
+	pldm_msgbuf_insert(buf, result_transfer_handle);
+	pldm_msgbuf_insert(buf, permission_flags->byte);
+	pldm_msgbuf_insert(buf, response_payload_length);
+	pldm_msgbuf_insert_uint8(buf, PLDM_RDE_VARSTRING_UTF_8);
+	pldm_msgbuf_insert(buf, (uint8_t)str_len);
+	rc = pldm_msgbuf_insert_array(buf, str_len, (const uint8_t *)etag,
+				      str_len);
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	if (response_payload_length > 0) {
+		rc = pldm_msgbuf_insert_array(buf, response_payload_length,
+					      (const uint8_t *)response_payload,
+					      response_payload_length);
+		if (rc != PLDM_SUCCESS) {
+			return rc;
+		}
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_rde_operation_init_resp(
+	const struct pldm_msg *msg, size_t payload_length,
+	uint8_t *completion_code, uint8_t *operation_status,
+	uint8_t *completion_percentage, uint32_t *completion_time_seconds,
+	bitfield8_t *operation_execution_flags,
+	uint32_t *result_transfer_handle, bitfield8_t *permission_flags,
+	uint32_t *response_payload_length, struct pldm_rde_varstring *etag,
+	uint8_t *response_payload)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || completion_code == NULL ||
+	    operation_status == NULL || completion_percentage == NULL ||
+	    completion_time_seconds == NULL ||
+	    operation_execution_flags == NULL ||
+	    result_transfer_handle == NULL || permission_flags == NULL ||
+	    response_payload_length == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+	rc = pldm_msgbuf_init_errno(buf,
+				    PLDM_RDE_OPERATION_INIT_RESP_FIXED_BYTES,
+				    msg->payload, payload_length);
+
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, operation_status);
+	pldm_msgbuf_extract_p(buf, completion_percentage);
+	pldm_msgbuf_extract_p(buf, completion_time_seconds);
+	pldm_msgbuf_extract_p(buf, &operation_execution_flags->byte);
+	pldm_msgbuf_extract_p(buf, result_transfer_handle);
+	pldm_msgbuf_extract_p(buf, &permission_flags->byte);
+	pldm_msgbuf_extract_p(buf, response_payload_length);
+	pldm_msgbuf_extract_p(buf, &etag->string_format);
+	pldm_msgbuf_extract_p(buf, &etag->string_length_bytes);
+	pldm_msgbuf_span_required(buf, etag->string_length_bytes,
+				  (void **)&etag->string_data);
+
+	if (*response_payload_length > 0) {
+		rc = pldm_msgbuf_extract_array(buf, *response_payload_length,
+					       response_payload,
+					       *response_payload_length);
+		if (rc) {
+			return pldm_msgbuf_discard(buf, rc);
+		}
+	}
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
 int encode_rde_operation_complete_req(uint8_t instance_id, uint32_t resource_id,
 				      rde_op_id operation_id,
 				      struct pldm_msg *msg)

--- a/tests/dsp/rde.cpp
+++ b/tests/dsp/rde.cpp
@@ -628,6 +628,136 @@ TEST(RDEMultipartReceiveTest, EncodeDecodeResoponseWithChecksumSuccess)
     EXPECT_EQ(decodeDataIntegrityChecksum, dataIntegrityChecksum);
 }
 
+TEST(RDEOperationInitTest, EncodeDecodeRequestSuccess)
+{
+    uint32_t resourceID = 1;
+    rde_op_id operationID = 1;
+    uint8_t operationType = PLDM_RDE_OPERATION_READ;
+    bitfield8_t operationFlags = {.byte = 0x03};
+    uint32_t sendDataTransferHandle = 1;
+    const uint8_t operationLocatorLength = 8;
+    const uint32_t requestPayloadLength = 4;
+    std::array<uint8_t, operationLocatorLength> operationLocator = {1, 2, 3, 4,
+                                                                    5, 6, 7, 8};
+    std::array<uint8_t, requestPayloadLength> requestPayload = {1, 2, 3, 4};
+
+    const uint32_t payloadLen = PLDM_RDE_OPERATION_INIT_REQ_FIXED_BYTES +
+                                operationLocatorLength + requestPayloadLength;
+
+    std::array<uint8_t, sizeof(pldm_msg_hdr) + payloadLen> requestMsg{};
+    pldm_msg* request = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_rde_operation_init_req(
+                  FIXED_INSTANCE_ID, resourceID, operationID, operationType,
+                  &operationFlags, sendDataTransferHandle,
+                  operationLocatorLength, requestPayloadLength,
+                  operationLocator.data(), requestPayload.data(), request),
+              PLDM_SUCCESS);
+
+    checkHeader(request, PLDM_RDE_OPERATION_INIT, PLDM_REQUEST);
+
+    uint32_t decodedResourceID;
+    rde_op_id decodedOperationID;
+    uint8_t decodedOperationType;
+    bitfield8_t decodedOperationFlags;
+    uint32_t decodedSendDataTransferHandle;
+    uint8_t decodedOperationLocatorLength;
+    uint32_t decodedRequestPayloadLength;
+    std::array<uint8_t, operationLocatorLength> decodedOperationLocator = {0};
+    std::array<uint8_t, requestPayloadLength> decodedRequestPayload = {0};
+
+    EXPECT_EQ(decode_rde_operation_init_req(
+                  request, payloadLen, &decodedResourceID, &decodedOperationID,
+                  &decodedOperationType, &decodedOperationFlags,
+                  &decodedSendDataTransferHandle,
+                  &decodedOperationLocatorLength, &decodedRequestPayloadLength,
+                  decodedOperationLocator.data(), decodedRequestPayload.data()),
+              PLDM_SUCCESS);
+
+    // Validate decoded values
+    EXPECT_EQ(decodedResourceID, resourceID);
+    EXPECT_EQ(decodedOperationID, operationID);
+    EXPECT_EQ(decodedOperationType, operationType);
+    EXPECT_EQ(decodedOperationFlags.byte, operationFlags.byte);
+    EXPECT_EQ(decodedSendDataTransferHandle, sendDataTransferHandle);
+    EXPECT_EQ(decodedOperationLocatorLength, operationLocatorLength);
+    EXPECT_EQ(decodedRequestPayloadLength, requestPayloadLength);
+
+    if (decodedOperationLocatorLength > 0)
+    {
+        EXPECT_EQ(decodedOperationLocator, operationLocator);
+    }
+    if (decodedRequestPayloadLength > 0)
+    {
+        EXPECT_EQ(decodedRequestPayload, requestPayload);
+    }
+}
+
+TEST(RDEOperationInitTest, EncodeDecodeResoponseSuccess)
+{
+    uint8_t completionCode = PLDM_SUCCESS;
+    uint8_t operationStatus = PLDM_RDE_OPERATION_COMPLETED;
+    uint8_t completionPercentage = 50;
+    uint32_t completionTimeSeconds = 0x7F;
+    bitfield8_t operationExecutionFlags = {.byte = 0x07};
+    uint32_t resultTransferHandle = 1;
+    bitfield8_t permissionFlags = {.byte = 0x03};
+    const uint32_t responsePayloadLength = 8;
+    const char* etag = "SampleData";
+    std::array<uint8_t, responsePayloadLength> responsePayload = {1, 2, 3, 4,
+                                                                  5, 6, 7, 8};
+    // size of etag("SampleData") is 10 + 1 for null terminator
+    const uint32_t payloadLen = PLDM_RDE_OPERATION_INIT_RESP_FIXED_BYTES +
+                                PLDM_RDE_VARSTRING_HEADER_SIZE + 11 +
+                                responsePayloadLength;
+
+    std::array<uint8_t, sizeof(struct pldm_msg_hdr) + payloadLen> requestMsg{};
+    pldm_msg* response = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_rde_operation_init_resp(
+                  FIXED_INSTANCE_ID, completionCode, operationStatus,
+                  completionPercentage, completionTimeSeconds,
+                  &operationExecutionFlags, resultTransferHandle,
+                  &permissionFlags, responsePayloadLength, etag,
+                  responsePayload.data(), response),
+              PLDM_SUCCESS);
+
+    checkHeader(response, PLDM_RDE_OPERATION_INIT, PLDM_RESPONSE);
+
+    uint8_t decodedCompletionCode;
+    uint8_t decodedOperationStatus;
+    uint8_t decodedCompletionPercentage;
+    uint32_t decodedCompletionTimeSeconds;
+    bitfield8_t decodedOperationExecutionFlags;
+    uint32_t decodedResultTransferHandle;
+    bitfield8_t decodedPermissionFlags;
+    uint32_t decodedResponsePayloadLength;
+    struct pldm_rde_varstring decodedEtag;
+    std::array<uint8_t, responsePayloadLength> decodedResponsePayload = {0};
+
+    EXPECT_EQ(decode_rde_operation_init_resp(
+                  response, payloadLen, &decodedCompletionCode,
+                  &decodedOperationStatus, &decodedCompletionPercentage,
+                  &decodedCompletionTimeSeconds,
+                  &decodedOperationExecutionFlags, &decodedResultTransferHandle,
+                  &decodedPermissionFlags, &decodedResponsePayloadLength,
+                  &decodedEtag, decodedResponsePayload.data()),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedCompletionCode, completionCode);
+    EXPECT_EQ(decodedOperationStatus, operationStatus);
+    EXPECT_EQ(decodedCompletionPercentage, completionPercentage);
+    EXPECT_EQ(decodedCompletionTimeSeconds, completionTimeSeconds);
+    EXPECT_EQ(decodedOperationExecutionFlags.byte,
+              operationExecutionFlags.byte);
+    EXPECT_EQ(decodedResultTransferHandle, resultTransferHandle);
+    EXPECT_EQ(decodedPermissionFlags.byte, permissionFlags.byte);
+    EXPECT_EQ(decodedResponsePayloadLength, responsePayloadLength);
+    EXPECT_EQ(decodedEtag.string_length_bytes, strlen(etag) + 1);
+    EXPECT_EQ(memcmp(etag, decodedEtag.string_data, strlen(etag)), 0);
+    EXPECT_EQ(decodedResponsePayload, responsePayload);
+}
+
 TEST(RDEOperationCompleteTest, EncodeDecodeRequestSuccess)
 {
     uint32_t resourceId = 0x12345678;


### PR DESCRIPTION
Add encode and decode APIs for RDEOperationInit command  as per DSP0218 v1.2 section 12.1

Tests:
Unit test passed.