### PR TITLE
RDE: add support for Get OEM and Registry Count cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Change categories:
 - rde: Add RDEOperationStatus support
 - rde: Add RDEOperationEnumerate support
 - rde: Add GetOEMCount support
+- rde: Add GetRegistryCount support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Change categories:
 - rde: Add RDEOperationComplete support
 - rde: Add RDEOperationStatus support
 - rde: Add RDEOperationEnumerate support
+- rde: Add GetOEMCount support
 
 - platform: Add decode_pldm_file_descriptor_pdr() and
   decode_pldm_file_descriptor_pdr_names()

--- a/include/libpldm/rde.h
+++ b/include/libpldm/rde.h
@@ -35,6 +35,8 @@ extern "C" {
 #define PLDM_RDE_OPERATION_STATUS_REQ_BYTES		    6
 #define PLDM_RDE_OPERATION_STATUS_RESP_FIXED_BYTES	    17
 #define PLDM_RDE_OPERATION_ENUMERATE_RESP_FIXED_BYTES	    3
+#define PLDM_GET_OEM_COUNT_REQ_BYTES			    5
+#define PLDM_GET_OEM_COUNT_RES_BYTES			    2
 
 enum pldm_rde_commands {
 	PLDM_NEGOTIATE_REDFISH_PARAMETERS = 0x01,
@@ -42,6 +44,7 @@ enum pldm_rde_commands {
 	PLDM_GET_SCHEMA_DICTIONARY = 0x03,
 	PLDM_GET_SCHEMA_URI = 0x04,
 	PLDM_GET_RESOURCE_ETAG = 0x05,
+	PLDM_GET_OEM_COUNT = 0x06,
 	PLDM_RDE_OPERATION_INIT = 0x10,
 	PLDM_RDE_OPERATION_COMPLETE = 0x13,
 	PLDM_RDE_OPERATION_STATUS = 0x14,
@@ -949,6 +952,58 @@ int decode_rde_operation_enumerate_resp(const struct pldm_msg *msg,
 					uint8_t *completion_code,
 					uint16_t *operation_count,
 					struct pldm_rde_op_entry *operations);
+
+/**
+ * @brief Encode GetOEMCount request.
+ *
+ * @param[in] instance_id - Message's instance ID.
+ * @param[in] resource_id - Resource ID of the target Redfish resource.
+ * @param[in] schema_class - The class of schema being requested.
+ * @param[in] payload_length - Length of the request message payload.
+ * @param[out] msg - Encoded PLDM message.
+ * @return pldm_completion_codes.
+ */
+int encode_get_oem_count_req(uint8_t instance_id, uint32_t resource_id,
+			     uint8_t schema_class, size_t payload_length,
+			     struct pldm_msg *msg);
+
+/**
+ * @brief Decode GetOEMCount request.
+ *
+ * @param[in] msg - PLDM message to decode.
+ * @param[in] payload_length - Length of the request message payload.
+ * @param[out] resource_id - Decoded Resource ID.
+ * @param[out] schema_class - Pointer to a uint8_t variable.
+ * @return pldm_completion_codes.
+ */
+int decode_get_oem_count_req(const struct pldm_msg *msg, size_t payload_length,
+			     uint32_t *resource_id, uint8_t *schema_class);
+
+/**
+ * @brief Encode GetOEMCount response.
+ *
+ * @param[in] instance_id - Message's instance ID.
+ * @param[in] completion_code - PLDM completion code.
+ * @param[in] oem_count - Number of OEM entries.
+ * @param[in] payload_length - Length of the response message payload.
+ * @param[out] msg - Encoded PLDM message.
+ * @return pldm_completion_codes.
+ */
+int encode_get_oem_count_resp(uint8_t instance_id, uint8_t completion_code,
+			      uint8_t oem_count, size_t payload_length,
+			      struct pldm_msg *msg);
+
+/**
+ * @brief Decode GetOEMCount response.
+ *
+ * @param[in] msg - PLDM message to decode.
+ * @param[in] payload_length - Length of the response message payload.
+ * @param[out] completion_code - Decoded PLDM completion code.
+ * @param[out] oem_count - Decoded OEM count.
+ * @return pldm_completion_codes.
+ */
+int decode_get_oem_count_resp(const struct pldm_msg *msg, size_t payload_length,
+			      uint8_t *completion_code, uint8_t *oem_count);
 
 #ifdef __cplusplus
 }

--- a/include/libpldm/rde.h
+++ b/include/libpldm/rde.h
@@ -37,6 +37,7 @@ extern "C" {
 #define PLDM_RDE_OPERATION_ENUMERATE_RESP_FIXED_BYTES	    3
 #define PLDM_GET_OEM_COUNT_REQ_BYTES			    5
 #define PLDM_GET_OEM_COUNT_RES_BYTES			    2
+#define PLDM_GET_REGISTRY_COUNT_RES_BYTES		    2
 
 enum pldm_rde_commands {
 	PLDM_NEGOTIATE_REDFISH_PARAMETERS = 0x01,
@@ -45,6 +46,7 @@ enum pldm_rde_commands {
 	PLDM_GET_SCHEMA_URI = 0x04,
 	PLDM_GET_RESOURCE_ETAG = 0x05,
 	PLDM_GET_OEM_COUNT = 0x06,
+	PLDM_GET_REGISTRY_COUNT = 0x08,
 	PLDM_RDE_OPERATION_INIT = 0x10,
 	PLDM_RDE_OPERATION_COMPLETE = 0x13,
 	PLDM_RDE_OPERATION_STATUS = 0x14,
@@ -1004,6 +1006,43 @@ int encode_get_oem_count_resp(uint8_t instance_id, uint8_t completion_code,
  */
 int decode_get_oem_count_resp(const struct pldm_msg *msg, size_t payload_length,
 			      uint8_t *completion_code, uint8_t *oem_count);
+
+/**
+ * @brief Encode GetRegistryCount request.
+ *
+ * @param[in] instance_id - Message's instance ID.
+ * @param[out] msg - Encoded PLDM request message.
+ * @return pldm_completion_codes.
+ */
+int encode_get_registry_count_req(uint8_t instance_id, struct pldm_msg *msg);
+
+/**
+ * @brief Encode GetRegistryCount response.
+ *
+ * @param[in] instance_id - Message's instance ID.
+ * @param[in] completion_code - PLDM completion code.
+ * @param[in] registry_count - Number of registry entries.
+ * @param[in] payload_length - Length of the response message payload.
+ * @param[out] msg - Encoded PLDM response message.
+ * @return pldm_completion_codes.
+ */
+int encode_get_registry_count_resp(uint8_t instance_id, uint8_t completion_code,
+				   uint8_t registry_count,
+				   size_t payload_length, struct pldm_msg *msg);
+
+/**
+ * @brief Decode GetRegistryCount response.
+ *
+ * @param[in] msg - PLDM response message to decode.
+ * @param[in] payload_length - Length of the response message payload.
+ * @param[out] completion_code - Decoded PLDM completion code.
+ * @param[out] registry_count - Decoded registry count.
+ * @return pldm_completion_codes.
+ */
+int decode_get_registry_count_resp(const struct pldm_msg *msg,
+				   size_t payload_length,
+				   uint8_t *completion_code,
+				   uint8_t *registry_count);
 
 #ifdef __cplusplus
 }

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -1950,3 +1950,135 @@ int decode_rde_operation_enumerate_resp(const struct pldm_msg *msg,
 
 	return pldm_msgbuf_complete(buf);
 }
+
+LIBPLDM_ABI_STABLE
+int encode_get_oem_count_req(uint8_t instance_id, uint32_t resource_id,
+			     uint8_t schema_class, size_t payload_length,
+			     struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.msg_type = PLDM_REQUEST;
+	header.command = PLDM_GET_OEM_COUNT;
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_GET_OEM_COUNT_REQ_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, resource_id);
+	pldm_msgbuf_insert(buf, schema_class);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_oem_count_req(const struct pldm_msg *msg, size_t payload_length,
+			     uint32_t *resource_id, uint8_t *schema_class)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || resource_id == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	if (payload_length != PLDM_GET_OEM_COUNT_REQ_BYTES) {
+		return PLDM_ERROR_INVALID_LENGTH;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_GET_OEM_COUNT_REQ_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, resource_id);
+	pldm_msgbuf_extract_p(buf, schema_class);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+
+int encode_get_oem_count_resp(uint8_t instance_id, uint8_t completion_code,
+			      uint8_t oem_count, size_t payload_length,
+			      struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (NULL == msg) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_GET_OEM_COUNT;
+
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_GET_OEM_COUNT_RES_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	if (completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_insert(buf, oem_count);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_oem_count_resp(const struct pldm_msg *msg, size_t payload_length,
+			      uint8_t *completion_code, uint8_t *oem_count)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || completion_code == NULL || oem_count == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_GET_OEM_COUNT_RES_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, oem_count);
+
+	return pldm_msgbuf_complete(buf);
+}

--- a/src/dsp/rde.c
+++ b/src/dsp/rde.c
@@ -2082,3 +2082,89 @@ int decode_get_oem_count_resp(const struct pldm_msg *msg, size_t payload_length,
 
 	return pldm_msgbuf_complete(buf);
 }
+
+LIBPLDM_ABI_STABLE
+int encode_get_registry_count_req(uint8_t instance_id, struct pldm_msg *msg)
+{
+	if (msg == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.msg_type = PLDM_REQUEST;
+	header.command = PLDM_GET_REGISTRY_COUNT;
+
+	return pack_pldm_header(&header, &(msg->hdr));
+}
+
+LIBPLDM_ABI_STABLE
+int encode_get_registry_count_resp(uint8_t instance_id, uint8_t completion_code,
+				   uint8_t registry_count,
+				   size_t payload_length, struct pldm_msg *msg)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (NULL == msg) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	struct pldm_header_info header = { 0 };
+	header.msg_type = PLDM_RESPONSE;
+	header.instance = instance_id;
+	header.pldm_type = PLDM_RDE;
+	header.command = PLDM_GET_REGISTRY_COUNT;
+
+	rc = pack_pldm_header(&header, &(msg->hdr));
+	if (rc != PLDM_SUCCESS) {
+		return rc;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_GET_REGISTRY_COUNT_RES_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_insert(buf, completion_code);
+	if (completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_insert(buf, registry_count);
+
+	return pldm_msgbuf_complete(buf);
+}
+
+LIBPLDM_ABI_STABLE
+int decode_get_registry_count_resp(const struct pldm_msg *msg,
+				   size_t payload_length,
+				   uint8_t *completion_code,
+				   uint8_t *registry_count)
+{
+	PLDM_MSGBUF_DEFINE_P(buf);
+	int rc;
+
+	if (msg == NULL || completion_code == NULL || registry_count == NULL) {
+		return PLDM_ERROR_INVALID_DATA;
+	}
+
+	rc = pldm_msgbuf_init_errno(buf, PLDM_GET_REGISTRY_COUNT_RES_BYTES,
+				    msg->payload, payload_length);
+	if (rc != PLDM_SUCCESS) {
+		fprintf(stderr, "init failed\n");
+		return rc;
+	}
+
+	pldm_msgbuf_extract_p(buf, completion_code);
+	if (*completion_code != PLDM_SUCCESS) {
+		return PLDM_SUCCESS;
+	}
+
+	pldm_msgbuf_extract_p(buf, registry_count);
+
+	return pldm_msgbuf_complete(buf);
+}

--- a/tests/dsp/rde.cpp
+++ b/tests/dsp/rde.cpp
@@ -1030,3 +1030,43 @@ TEST(GetOEMCountTest, EncodeDecodeResponseSuccess)
     EXPECT_EQ(decodedCompletionCode, completionCode);
     EXPECT_EQ(decodedOEMCount, oemCount);
 }
+
+TEST(GetRegistryCountTest, EncodeRequestSuccess)
+{
+    std::array<uint8_t, sizeof(pldm_msg_hdr)> requestMsg{};
+    pldm_msg* request = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_get_registry_count_req(FIXED_INSTANCE_ID, request),
+              PLDM_SUCCESS);
+
+    checkHeader(request, PLDM_GET_REGISTRY_COUNT, PLDM_REQUEST);
+}
+
+TEST(GetRegistryCountTest, EncodeDecodeResponseSuccess)
+{
+    uint8_t completionCode = PLDM_SUCCESS;
+    uint32_t registryCount = 0xFF;
+
+    std::array<uint8_t,
+               sizeof(struct pldm_msg_hdr) + PLDM_GET_REGISTRY_COUNT_RES_BYTES>
+        responseMsg{};
+    pldm_msg* response = (pldm_msg*)responseMsg.data();
+
+    EXPECT_EQ(encode_get_registry_count_resp(
+                  FIXED_INSTANCE_ID, completionCode, registryCount,
+                  PLDM_GET_REGISTRY_COUNT_RES_BYTES, response),
+              PLDM_SUCCESS);
+
+    checkHeader(response, PLDM_GET_REGISTRY_COUNT, PLDM_RESPONSE);
+
+    uint8_t decodedCompletionCode;
+    uint8_t decodedRegistryCount;
+
+    EXPECT_EQ(decode_get_registry_count_resp(
+                  response, PLDM_GET_REGISTRY_COUNT_RES_BYTES,
+                  &decodedCompletionCode, &decodedRegistryCount),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedCompletionCode, completionCode);
+    EXPECT_EQ(decodedRegistryCount, registryCount);
+}

--- a/tests/dsp/rde.cpp
+++ b/tests/dsp/rde.cpp
@@ -973,3 +973,60 @@ TEST(RDEOperationEnumerateTest, EncodeDecodeResponseWithNoOperationSuccess)
     EXPECT_EQ(decodedCompletionCode, completionCode);
     EXPECT_EQ(decodedOperationCount, operationCount);
 }
+
+TEST(GetOEMCountTest, EncodeDecodeRequestSuccess)
+{
+    uint32_t resourceID = 0xDEADBEEF;
+    uint8_t schemaClass = 0xff;
+
+    std::array<uint8_t,
+               sizeof(struct pldm_msg_hdr) + PLDM_GET_OEM_COUNT_REQ_BYTES>
+        requestMsg{};
+    pldm_msg* request = (pldm_msg*)requestMsg.data();
+
+    EXPECT_EQ(encode_get_oem_count_req(FIXED_INSTANCE_ID, resourceID,
+                                       schemaClass,
+                                       PLDM_GET_OEM_COUNT_REQ_BYTES, request),
+              PLDM_SUCCESS);
+
+    checkHeader(request, PLDM_GET_OEM_COUNT, PLDM_REQUEST);
+
+    uint32_t decodedResourceID;
+    uint8_t decodedSchemaClass;
+
+    EXPECT_EQ(decode_get_oem_count_req(request, PLDM_GET_OEM_COUNT_REQ_BYTES,
+                                       &decodedResourceID, &decodedSchemaClass),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedResourceID, resourceID);
+    EXPECT_EQ(decodedSchemaClass, schemaClass);
+}
+
+TEST(GetOEMCountTest, EncodeDecodeResponseSuccess)
+{
+    uint8_t completionCode = PLDM_SUCCESS;
+    uint32_t oemCount = 0xFF;
+
+    std::array<uint8_t,
+               sizeof(struct pldm_msg_hdr) + PLDM_GET_OEM_COUNT_RES_BYTES>
+        responseMsg{};
+    pldm_msg* response = (pldm_msg*)responseMsg.data();
+
+    EXPECT_EQ(encode_get_oem_count_resp(FIXED_INSTANCE_ID, completionCode,
+                                        oemCount, PLDM_GET_OEM_COUNT_RES_BYTES,
+                                        response),
+              PLDM_SUCCESS);
+
+    checkHeader(response, PLDM_GET_OEM_COUNT, PLDM_RESPONSE);
+
+    uint8_t decodedCompletionCode;
+    uint8_t decodedOEMCount;
+
+    EXPECT_EQ(decode_get_oem_count_resp(response, PLDM_GET_OEM_COUNT_RES_BYTES,
+                                        &decodedCompletionCode,
+                                        &decodedOEMCount),
+              PLDM_SUCCESS);
+
+    EXPECT_EQ(decodedCompletionCode, completionCode);
+    EXPECT_EQ(decodedOEMCount, oemCount);
+}


### PR DESCRIPTION
Add encode and decode APIs for GetOEMCount and GetRegistryCount
commands.

Tests:
Unit tests passed.
'''
[----------] 2 tests from GetOEMCountTest
[ RUN      ] GetOEMCountTest.EncodeDecodeRequestSuccess
[       OK ] GetOEMCountTest.EncodeDecodeRequestSuccess (0 ms)
[ RUN      ] GetOEMCountTest.EncodeDecodeResponseSuccess
[       OK ] GetOEMCountTest.EncodeDecodeResponseSuccess (0 ms)
[----------] 2 tests from GetOEMCountTest (0 ms total)

[----------] 2 tests from GetRegistryCountTest
[ RUN      ] GetRegistryCountTest.EncodeRequestSuccess
[       OK ] GetRegistryCountTest.EncodeRequestSuccess (0 ms)
[ RUN      ] GetRegistryCountTest.EncodeDecodeResponseSuccess
[       OK ] GetRegistryCountTest.EncodeDecodeResponseSuccess (0 ms)
[----------] 2 tests from GetRegistryCountTest (0 ms total)
'''